### PR TITLE
Support multiple returns

### DIFF
--- a/src/analysis/available.rs
+++ b/src/analysis/available.rs
@@ -150,20 +150,20 @@ impl GenerationPass for AvailableValuePass {
                 // out[n] = gen[n] U (in[n] - kill[n]) U (callee_saved if n is entry)
                 let mut out_reg_n = node
                     .reg_values_in()
-                    .difference(&node.node.kill_reg_value())
-                    .union(&node.node.gen_reg_value())
+                    .difference(&node.node().kill_reg_value())
+                    .union(&node.node().gen_reg_value())
                     .union_if(
                         &RegSets::callee_saved().into_available(),
-                        node.node.is_any_entry(),
+                        node.node().is_any_entry(),
                     );
 
                 // out_stacks[n] = (gen_stacks[n] if we know the location of the stack pointer) U in_stacks[n]
                 // (There is no kill_stacks[n])
-                let mut out_stack_n = if node.node.is_any_entry() {
+                let mut out_stack_n = if node.node().is_any_entry() {
                     HashMap::new()
                 } else {
                     node.stack_values_in().union_filter_map(
-                        &node.node.gen_stack_value(),
+                        &node.node().gen_stack_value(),
                         |(off, val)| {
                             node.reg_values_in()
                                 .stack_offset()
@@ -177,10 +177,10 @@ impl GenerationPass for AvailableValuePass {
                 // We use a series of rules to determine new available values
                 // that change our outs.
 
-                rule_expand_address_for_load(&node.node, &mut out_reg_n, &node.reg_values_in());
-                rule_perform_math_ops(&node.node, &mut out_reg_n, &node.reg_values_in());
-                rule_known_values_to_stack(&node.node, &mut out_stack_n, &node.reg_values_in());
-                rule_value_from_stack(&node.node, &mut out_reg_n, &node.stack_values_in());
+                rule_expand_address_for_load(&node.node(), &mut out_reg_n, &node.reg_values_in());
+                rule_perform_math_ops(&node.node(), &mut out_reg_n, &node.reg_values_in());
+                rule_known_values_to_stack(&node.node(), &mut out_stack_n, &node.reg_values_in());
+                rule_value_from_stack(&node.node(), &mut out_reg_n, &node.stack_values_in());
 
                 // If either of the outs changed, replace the old outs with the new outs
                 // and mark that we changed something.

--- a/src/analysis/liveness.rs
+++ b/src/analysis/liveness.rs
@@ -33,7 +33,7 @@ impl GenerationPass for LivenessPass {
                         .live_out()
                         .intersection_c(&func.exit.u_def())
                         .union_c(&func.exit.live_in())
-                        .union_c(&func.exit.node.gen_reg());
+                        .union_c(&func.exit.node().gen_reg());
 
                     if func_exit_live_in != func.exit.live_in() {
                         changed = true;
@@ -76,7 +76,7 @@ impl GenerationPass for LivenessPass {
                         changed = true;
                         node.set_u_def(u_def);
                     }
-                } else if node.node.is_ecall() {
+                } else if node.node().is_ecall() {
                     // TODO check if saved registers get screwed up here
 
                     // u_def[n] = live_out[n]
@@ -102,7 +102,7 @@ impl GenerationPass for LivenessPass {
                         changed = true;
                         node.set_u_def(u_def);
                     }
-                } else if node.node.is_return() {
+                } else if node.node().is_return() {
                     // u_def[n] = AND u_def[s] for all s in prev[n]
                     let u_def = node
                         .prevs()
@@ -116,12 +116,12 @@ impl GenerationPass for LivenessPass {
                         changed = true;
                         node.set_u_def(u_def);
                     }
-                } else if node.node.is_function_entry() {
+                } else if node.node().is_function_entry() {
                     // live_in[n] = gen[n] U (live_out[n] - kill[n])
                     let live_in = node
                         .live_out()
-                        .difference_c(&node.node.kill_reg())
-                        .union_c(&node.node.gen_reg());
+                        .difference_c(&node.node().kill_reg())
+                        .union_c(&node.node().gen_reg());
 
                     // u_def[n] = live_in[n]
                     let u_def = live_in.clone();
@@ -147,8 +147,8 @@ impl GenerationPass for LivenessPass {
                     // live_in[n] = gen[n] U (live_out[n] - kill[n])
                     let live_in = node
                         .live_out()
-                        .difference_c(&node.node.kill_reg())
-                        .union_c(&node.node.gen_reg());
+                        .difference_c(&node.node().kill_reg())
+                        .union_c(&node.node().gen_reg());
 
                     if live_in != node.live_in() {
                         changed = true;

--- a/src/cfg/display.rs
+++ b/src/cfg/display.rs
@@ -40,7 +40,7 @@ where
 
 impl Display for CFGNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{}\n", self.node))?;
+        f.write_fmt(format_args!("{}\n", self.node()))?;
         f.write_fmt(format_args!("  | LIVE | {}\n", self.live_out().str()))?;
         f.write_fmt(format_args!("  | VALS | {}\n", self.reg_values_out().str()))?;
         f.write_fmt(format_args!(

--- a/src/cfg/graph.rs
+++ b/src/cfg/graph.rs
@@ -18,15 +18,6 @@ pub struct Cfg {
     pub label_function_map: HashMap<With<LabelString>, Rc<Function>>,
 }
 
-// impl FromStr for Cfg {
-//     type Err = Box<CFGError>;
-//     fn from_str(s: &str) -> Result<Self, Self::Err> {
-//         let parser = Parser::new(s);
-//         let nodes = parser.collect::<Vec<ParserNode>>();
-//         Cfg::new(nodes)
-//     }
-// }
-
 impl IntoIterator for &Cfg {
     type Item = Rc<CFGNode>;
     type IntoIter = std::vec::IntoIter<Self::Item>;

--- a/src/gen/dead_code.rs
+++ b/src/gen/dead_code.rs
@@ -16,7 +16,7 @@ impl GenerationPass for EliminateDeadCodeDirectionsPass {
             changed = false;
             let old = nodes.clone();
             for node in nodes {
-                if node.node.is_return() || node.node.is_any_entry() {
+                if node.node().is_return() || node.node().is_any_entry() {
                     continue;
                 }
                 // If the node has no nexts, remove it from the prevs of all its prevs

--- a/src/gen/directions.rs
+++ b/src/gen/directions.rs
@@ -16,7 +16,7 @@ impl GenerationPass for NodeDirectionPass {
         let mut prev = None;
         for node in nodes {
             // If node jumps to another node, add it to the nexts of the current node and the prevs of the node it jumps to.
-            if let Some(label) = node.node.jumps_to() {
+            if let Some(label) = node.node().jumps_to() {
                 let jump_to_node = nodes
                     .iter()
                     .find(|n| n.labels.contains(&label))
@@ -33,7 +33,7 @@ impl GenerationPass for NodeDirectionPass {
             }
 
             // Set previous node to current node, if it is not a return
-            prev = if node.node.is_return() {
+            prev = if node.node().is_return() {
                 None
             } else {
                 Some(Rc::clone(node))

--- a/src/gen/function_annotations.rs
+++ b/src/gen/function_annotations.rs
@@ -2,38 +2,43 @@ use std::{collections::HashMap, rc::Rc, vec};
 
 use crate::{
     cfg::{Cfg, Function},
+    parser::Register,
+    parser::{Info, JumpLinkType, LabelString, LineDisplay, ParserNode, With},
     passes::{CFGError, GenerationPass},
 };
 
 pub struct FunctionMarkupPass;
 impl GenerationPass for FunctionMarkupPass {
     fn run(cfg: &mut Cfg) -> Result<(), Box<CFGError>> {
-        let mut label_function_map = HashMap::new();
+        let mut label_function_map: HashMap<
+            crate::parser::With<crate::parser::LabelString>,
+            Rc<Function>,
+        > = HashMap::new();
 
         // PASS 1
         // --------------------
         // Graph traversal to find functions
 
         for node in cfg.into_iter() {
-            if node.node.is_return() {
+            if node.node().is_return() {
                 // Walk backwards from return label to find function starts
                 let mut walked = Vec::new();
                 let mut queue = vec![Rc::clone(&node)];
                 let mut found = Vec::new();
 
                 // For all items in the queue
-                'inn: while let Some(n) = queue.pop() {
+                'inner: while let Some(n) = queue.pop() {
                     walked.push(Rc::clone(&n));
 
                     // If we reach the program entry, there's an issue
-                    if n.node.is_program_entry() {
-                        return Err(Box::new(CFGError::NoLabelForReturn(node.node.clone())));
+                    if n.node().is_program_entry() {
+                        return Err(Box::new(CFGError::NoLabelForReturn(node.node().clone())));
                     }
 
                     // If we find a function entry, we're done
-                    if n.node.is_function_entry() {
+                    if n.node().is_function_entry() {
                         found.push(Rc::clone(&n));
-                        continue 'inn;
+                        continue 'inner;
                     }
 
                     // Otherwise, add all previous nodes to the queue
@@ -47,33 +52,68 @@ impl GenerationPass for FunctionMarkupPass {
                 // If we found multiple function entries, we have a problem
                 if found.len() > 1 {
                     return Err(Box::new(CFGError::MultipleLabelsForReturn(
-                        node.node.clone(),
+                        node.node().clone(),
                         found.iter().flat_map(|x| x.labels.clone()).collect(),
                     )));
                 }
 
                 // Otherwise, we found a function and all its nodes
                 if let Some(entry_node) = found.first() {
+                    // Add the function to the map
                     let func = Rc::new(Function::new(
                         walked,
                         Rc::clone(entry_node),
                         Rc::clone(&node),
                     ));
 
-                    // Add the function to the map
-                    for label in func.labels() {
-                        if let Some(func2) =
-                            label_function_map.insert(label.clone(), Rc::clone(&func))
-                        {
-                            // If we already have a function for this label, we have a problem
-                            let mut labels = func2.labels();
-                            labels.extend(func.labels());
-                            return Err(Box::new(CFGError::MultipleReturnsForLabel(
-                                labels.into_iter().collect(),
-                                vec![func.exit.node.clone(), func2.exit.node.clone()]
-                                    .into_iter()
-                                    .collect(),
-                            )));
+                    // The label function map can have multiple entries corresponding to the single
+                    // function, because that function has multiple labels. That makes this a bit
+                    // messy because we want to ensure that every case is covered.
+                    let mut exists = None;
+                    'inn: for label in entry_node.labels() {
+                        if let Some(existing_func) = label_function_map.get(&label) {
+                            // Since we already have a "return" for this function,
+                            // we will convert the new return to an unconditional jump
+                            // to the existing return
+                            exists = Some(existing_func);
+                            break 'inn;
+                        }
+                    }
+
+                    if let Some(existing_func) = exists {
+                        // Convert the return node to an unconditional jump
+
+                        // Get the return node, which will become an unconditional jump
+                        let return_node = Rc::clone(&node);
+
+                        // Get the existing return node -- will stay the same
+                        let existing_return_node = Rc::clone(&existing_func.exit);
+
+                        // Clear nexts of return node, and add existing return
+                        // TODO convert next/prev setting to function to enforce
+                        // At this point, the nexts of the return nodes should be all empty
+                        // TODO assert that the nexts for both don't exist
+                        return_node.clear_nexts();
+                        return_node.insert_next(Rc::clone(&existing_return_node));
+
+                        // Set return node's prev to original return node
+                        existing_return_node.insert_prev(Rc::clone(&return_node));
+
+                        // Convert node to jump
+                        let inf = Info {
+                            token: crate::parser::Token::Symbol("return".to_string()),
+                            pos: return_node.node().range().clone(),
+                            file: return_node.node().file().clone(),
+                        };
+
+                        let inst = With::new(JumpLinkType::Jal, inf.clone());
+                        let rd = With::new(Register::X0, inf.clone());
+                        let name = With::new(LabelString("__return__".to_string()), inf.clone());
+                        let new_node = ParserNode::new_jump_link(inst, rd, name);
+                        return_node.set_node(new_node);
+                    } else {
+                        for label in entry_node.labels() {
+                            label_function_map.insert(label.clone(), Rc::clone(&func));
                         }
                     }
 
@@ -83,7 +123,7 @@ impl GenerationPass for FunctionMarkupPass {
                     }
                 } else {
                     // If we found no function entries, we have a problem
-                    return Err(Box::new(CFGError::NoLabelForReturn(node.node.clone())));
+                    return Err(Box::new(CFGError::NoLabelForReturn(node.node().clone())));
                 }
             }
         }

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -212,6 +212,9 @@ fn get_string(value: Option<Info>) -> Result<With<String>, LexError> {
 impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
     type Error = LexError;
 
+    // TODO enforce that all "missing" values for With<> resolve to the token
+    // of the instruction
+
     #[allow(clippy::too_many_lines)]
     fn try_from(value: &mut Peekable<Lexer>) -> Result<Self, Self::Error> {
         use LexError::{Expected, Ignored, IsNewline, NeedTwoNodes, UnexpectedEOF};

--- a/src/passes/cfg_error.rs
+++ b/src/passes/cfg_error.rs
@@ -20,11 +20,6 @@ pub enum CFGError {
     /// This error occurs when a return statement is used but can be reached by
     /// no labels.
     NoLabelForReturn(ParserNode),
-    /// This error occurs when there are multiple returns for a label.
-    ///
-    /// This error is temporary and will be removed from a future version of
-    /// the compiler.
-    MultipleReturnsForLabel(HashSet<With<LabelString>>, HashSet<ParserNode>),
     /// Unexpected error
     UnexpectedError,
     /// Assertion error


### PR DESCRIPTION
Adds support for multiple return statements by remapping all other return statements to unconditional jumps to return blocks.

This was done for ease of implementation, so we don't have to introduce new blocks.

closes #13