### PR TITLE
[RV-16] refactor: rename all usages of CFG to Cfg

### DIFF
--- a/riscv_analysis/src/analysis/available.rs
+++ b/riscv_analysis/src/analysis/available.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::parser::{LabelString, RegSets};
 use crate::parser::{ParserNode, Register};
-use crate::passes::{CFGError, GenerationPass};
+use crate::passes::{CfgError, GenerationPass};
 
 use super::{CustomDifference, CustomIntersection, CustomInto, CustomUnion, CustomUnionFilterMap};
 
@@ -133,7 +133,7 @@ impl AvailableStackHelpers for HashMap<Register, AvailableValue> {
 ///
 pub struct AvailableValuePass;
 impl GenerationPass for AvailableValuePass {
-    fn run(cfg: &mut crate::cfg::Cfg) -> Result<(), Box<CFGError>> {
+    fn run(cfg: &mut crate::cfg::Cfg) -> Result<(), Box<CfgError>> {
         let mut changed = true;
 
         // Because of this type of algorithm, there might be a back branch,

--- a/riscv_analysis/src/analysis/liveness.rs
+++ b/riscv_analysis/src/analysis/liveness.rs
@@ -1,6 +1,6 @@
 use crate::{
     parser::RegSets,
-    passes::{CFGError, GenerationPass},
+    passes::{CfgError, GenerationPass},
 };
 use std::collections::HashSet;
 
@@ -9,7 +9,7 @@ use super::CustomClonedSets;
 pub struct LivenessPass;
 impl GenerationPass for LivenessPass {
     #[allow(clippy::too_many_lines)]
-    fn run(cfg: &mut crate::cfg::Cfg) -> Result<(), Box<CFGError>> {
+    fn run(cfg: &mut crate::cfg::Cfg) -> Result<(), Box<CfgError>> {
         let mut changed = true;
         #[allow(clippy::mutable_key_type)]
         let mut visited = HashSet::new();

--- a/riscv_analysis/src/cfg/display.rs
+++ b/riscv_analysis/src/cfg/display.rs
@@ -5,7 +5,7 @@ use std::{
 
 use itertools::Itertools;
 
-use super::{CFGNode, Cfg};
+use super::{Cfg, CfgNode};
 
 pub trait SetListString {
     fn str(&self) -> String;
@@ -40,7 +40,7 @@ where
     }
 }
 
-impl Display for CFGNode {
+impl Display for CfgNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("{}\n", self.node()))?;
         f.write_fmt(format_args!("  | LIVI | {}\n", self.live_in().str()))?;

--- a/riscv_analysis/src/cfg/function.rs
+++ b/riscv_analysis/src/cfg/function.rs
@@ -5,13 +5,13 @@ use crate::{
     parser::{LabelString, RegSets, Register, With},
 };
 
-use super::CFGNode;
+use super::CfgNode;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Function {
-    pub nodes: Vec<Rc<CFGNode>>,
-    pub entry: Rc<CFGNode>, // Is only a FuncEntry node
-    pub exit: Rc<CFGNode>,  // Multiple exit points will be converted to
+    pub nodes: Vec<Rc<CfgNode>>,
+    pub entry: Rc<CfgNode>, // Is only a FuncEntry node
+    pub exit: Rc<CfgNode>,  // Multiple exit points will be converted to
     // a single exit point
     /// The registers that are set ever in the function
     pub defs: HashSet<Register>,
@@ -30,9 +30,9 @@ impl Function {
         )
     }
     pub fn new(
-        nodes: Vec<Rc<CFGNode>>,
-        entry: Rc<CFGNode>,
-        exit: Rc<CFGNode>,
+        nodes: Vec<Rc<CfgNode>>,
+        entry: Rc<CfgNode>,
+        exit: Rc<CfgNode>,
         defs: HashSet<Register>,
     ) -> Self {
         Function {

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -15,7 +15,7 @@ use super::Cfg;
 use super::Function;
 
 #[derive(Debug)]
-pub struct CFGNode {
+pub struct CfgNode {
     /// Parser node that this CFG node is wrapping.
     node: RefCell<ParserNode>,
     /// Any labels that refer to this instruction.
@@ -23,9 +23,9 @@ pub struct CFGNode {
     /// Is this node inside the data section?
     pub data_section: bool,
     /// CFG nodes that come after this one (forward edges).
-    nexts: RefCell<HashSet<Rc<CFGNode>>>,
+    nexts: RefCell<HashSet<Rc<CfgNode>>>,
     /// CFG nodes that come before this one (backward edges).
-    prevs: RefCell<HashSet<Rc<CFGNode>>>,
+    prevs: RefCell<HashSet<Rc<CfgNode>>>,
     /// If this CFG node is part of a function, which function
     /// is it part of?
     ///
@@ -101,10 +101,10 @@ pub struct CFGNode {
     u_def: RefCell<HashSet<Register>>,
 }
 
-impl CFGNode {
+impl CfgNode {
     #[must_use]
     pub fn new(node: ParserNode, labels: HashSet<With<LabelString>>, data_section: bool) -> Self {
-        CFGNode {
+        CfgNode {
             node: RefCell::new(node),
             labels,
             data_section,
@@ -129,11 +129,11 @@ impl CFGNode {
         self.node.borrow().clone()
     }
 
-    pub fn nexts(&self) -> Ref<HashSet<Rc<CFGNode>>> {
+    pub fn nexts(&self) -> Ref<HashSet<Rc<CfgNode>>> {
         self.nexts.borrow()
     }
 
-    pub fn prevs(&self) -> Ref<HashSet<Rc<CFGNode>>> {
+    pub fn prevs(&self) -> Ref<HashSet<Rc<CfgNode>>> {
         self.prevs.borrow()
     }
 
@@ -236,11 +236,11 @@ impl CFGNode {
         self.known_ecall() == Some(10) || self.known_ecall() == Some(93)
     }
 
-    pub fn insert_next(&self, next: Rc<CFGNode>) {
+    pub fn insert_next(&self, next: Rc<CfgNode>) {
         self.nexts.borrow_mut().insert(next);
     }
 
-    pub fn remove_next(&self, next: &Rc<CFGNode>) {
+    pub fn remove_next(&self, next: &Rc<CfgNode>) {
         self.nexts.borrow_mut().remove(next);
     }
 
@@ -248,11 +248,11 @@ impl CFGNode {
         self.nexts.borrow_mut().clear();
     }
 
-    pub fn insert_prev(&self, prev: Rc<CFGNode>) {
+    pub fn insert_prev(&self, prev: Rc<CfgNode>) {
         self.prevs.borrow_mut().insert(prev);
     }
 
-    pub fn remove_prev(&self, prev: &Rc<CFGNode>) {
+    pub fn remove_prev(&self, prev: &Rc<CfgNode>) {
         self.prevs.borrow_mut().remove(prev);
     }
 
@@ -274,15 +274,15 @@ impl CFGNode {
     }
 }
 
-impl Hash for CFGNode {
+impl Hash for CfgNode {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.node().hash(state);
     }
 }
 
-impl PartialEq for CFGNode {
+impl PartialEq for CfgNode {
     fn eq(&self, other: &Self) -> bool {
         self.node == other.node
     }
 }
-impl Eq for CFGNode {}
+impl Eq for CfgNode {}

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -8,7 +8,7 @@ use crate::{
     parser::{ParserNode, Register},
 };
 
-use super::{CFGNode, Cfg};
+use super::{Cfg, CfgNode};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct NodeWrapper {
@@ -81,7 +81,7 @@ pub struct NodeWrapper {
 }
 
 impl NodeWrapper {
-    fn from(node: &CFGNode, cfg: &Cfg) -> Self {
+    fn from(node: &CfgNode, cfg: &Cfg) -> Self {
         NodeWrapper {
             node: node.node(),
             labels: node.labels.iter().map(|x| x.data.0.clone()).collect(),
@@ -129,11 +129,11 @@ impl NodeWrapper {
 }
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct CFGWrapper(Vec<NodeWrapper>);
+pub struct CfgWrapper(Vec<NodeWrapper>);
 
-impl From<&Cfg> for CFGWrapper {
+impl From<&Cfg> for CfgWrapper {
     fn from(cfg: &Cfg) -> Self {
-        CFGWrapper(
+        CfgWrapper(
             cfg.nodes
                 .iter()
                 .map(|x| NodeWrapper::from(x, cfg))

--- a/riscv_analysis/src/gen/dead_code.rs
+++ b/riscv_analysis/src/gen/dead_code.rs
@@ -1,11 +1,11 @@
 use crate::{
     cfg::Cfg,
-    passes::{CFGError, GenerationPass},
+    passes::{CfgError, GenerationPass},
 };
 
 pub struct EliminateDeadCodeDirectionsPass;
 impl GenerationPass for EliminateDeadCodeDirectionsPass {
-    fn run(cfg: &mut Cfg) -> Result<(), Box<CFGError>> {
+    fn run(cfg: &mut Cfg) -> Result<(), Box<CfgError>> {
         // PASS 3:
         // --------------------
         // Eliminate nexts and prevs for dead code

--- a/riscv_analysis/src/gen/directions.rs
+++ b/riscv_analysis/src/gen/directions.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::{
     cfg::Cfg,
-    passes::{CFGError, GenerationPass},
+    passes::{CfgError, GenerationPass},
 };
 
 /// Calculate the next and previous nodes for each node in the CFG.
@@ -11,7 +11,7 @@ use crate::{
 /// This must be run before most passes.
 pub struct NodeDirectionPass;
 impl GenerationPass for NodeDirectionPass {
-    fn run(cfg: &mut Cfg) -> Result<(), Box<CFGError>> {
+    fn run(cfg: &mut Cfg) -> Result<(), Box<CfgError>> {
         let nodes = &cfg.nodes;
         let mut prev = None;
         for node in nodes {
@@ -20,7 +20,7 @@ impl GenerationPass for NodeDirectionPass {
                 let jump_to_node = nodes
                     .iter()
                     .find(|n| n.labels.contains(&label))
-                    .ok_or_else(|| CFGError::UnexpectedError)?;
+                    .ok_or_else(|| CfgError::UnexpectedError)?;
 
                 node.insert_next(Rc::clone(jump_to_node));
                 jump_to_node.insert_prev(Rc::clone(node));

--- a/riscv_analysis/src/gen/ecall_terminate.rs
+++ b/riscv_analysis/src/gen/ecall_terminate.rs
@@ -1,9 +1,9 @@
-use crate::passes::CFGError;
+use crate::passes::CfgError;
 use crate::passes::GenerationPass;
 
 pub struct EcallTerminationPass;
 impl GenerationPass for EcallTerminationPass {
-    fn run(cfg: &mut crate::cfg::Cfg) -> Result<(), Box<CFGError>> {
+    fn run(cfg: &mut crate::cfg::Cfg) -> Result<(), Box<CfgError>> {
         for node in &*cfg {
             if node.is_program_exit() {
                 for temp_node in node.nexts().clone() {

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -8,12 +8,12 @@ use crate::{
     cfg::{Cfg, Function},
     parser::Register,
     parser::{Info, JumpLinkType, LabelString, ParserNode, With},
-    passes::{CFGError, DiagnosticLocation, GenerationPass},
+    passes::{CfgError, DiagnosticLocation, GenerationPass},
 };
 
 pub struct FunctionMarkupPass;
 impl GenerationPass for FunctionMarkupPass {
-    fn run(cfg: &mut Cfg) -> Result<(), Box<CFGError>> {
+    fn run(cfg: &mut Cfg) -> Result<(), Box<CfgError>> {
         let mut label_function_map: HashMap<
             crate::parser::With<crate::parser::LabelString>,
             Rc<Function>,
@@ -40,7 +40,7 @@ impl GenerationPass for FunctionMarkupPass {
 
                     // If we reach the program entry, there's an issue
                     if n.node().is_program_entry() {
-                        return Err(Box::new(CFGError::NoLabelForReturn(node.node())));
+                        return Err(Box::new(CfgError::NoLabelForReturn(node.node())));
                     }
 
                     // If we find a function entry, we're done
@@ -59,7 +59,7 @@ impl GenerationPass for FunctionMarkupPass {
 
                 // If we found multiple function entries, we have a problem
                 if found.len() > 1 {
-                    return Err(Box::new(CFGError::MultipleLabelsForReturn(
+                    return Err(Box::new(CfgError::MultipleLabelsForReturn(
                         node.node(),
                         found.iter().flat_map(|x| x.labels.clone()).collect(),
                     )));
@@ -137,7 +137,7 @@ impl GenerationPass for FunctionMarkupPass {
                     }
                 } else {
                     // If we found no function entries, we have a problem
-                    return Err(Box::new(CFGError::NoLabelForReturn(node.node())));
+                    return Err(Box::new(CfgError::NoLabelForReturn(node.node())));
                 }
             }
         }

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -1,7 +1,7 @@
 use crate::analysis::AvailableRegisterValues;
 use crate::analysis::AvailableValue;
 use crate::analysis::CustomClonedSets;
-use crate::cfg::CFGNode;
+use crate::cfg::CfgNode;
 use crate::cfg::Cfg;
 use crate::parser::ParserNode;
 use crate::parser::RegSets;
@@ -23,7 +23,7 @@ impl Cfg {
     /// This function works by traversing the previous nodes until it finds a node that stores to the given register.
     /// This is used to correctly mark up the first store to a register that might
     /// have been incorrect.
-    fn error_ranges_for_first_store(node: &Rc<CFGNode>, item: Register) -> Vec<With<Register>> {
+    fn error_ranges_for_first_store(node: &Rc<CfgNode>, item: Register) -> Vec<With<Register>> {
         let mut queue = VecDeque::new();
         let mut ranges = Vec::new();
         // push the previous nodes onto the queue
@@ -55,7 +55,7 @@ impl Cfg {
 
     // TODO move to a more appropriate place
     // TODO make better, what even is this?
-    fn error_ranges_for_first_usage(node: &Rc<CFGNode>, item: Register) -> Vec<With<Register>> {
+    fn error_ranges_for_first_usage(node: &Rc<CfgNode>, item: Register) -> Vec<With<Register>> {
         let mut queue = VecDeque::new();
         let mut ranges = Vec::new();
         // push the next nodes onto the queue

--- a/riscv_analysis/src/passes/cfg_error.rs
+++ b/riscv_analysis/src/passes/cfg_error.rs
@@ -5,14 +5,14 @@ use crate::parser::{LabelString, ParserNode, With};
 use super::{DiagnosticLocation, DiagnosticMessage, WarningLevel};
 
 #[derive(Debug, Clone)]
-// TODO CFGErrors that do not require the whole thing to be re-run
+// TODO CfgErrors that do not require the whole thing to be re-run
 
-/// `CFGError` is an error that occurs while generating an annotated CFG.
+/// `CfgError` is an error that occurs while generating an annotated CFG.
 ///
 /// These errors are non-recoverable and will cause the program to exit at
 /// the point of error. As much effort should be done to avoid these errors
 /// and to use `LintErrors`, as those are recoverable.
-pub enum CFGError {
+pub enum CfgError {
     /// This error occurs when a label is used but not defined.
     LabelsNotDefined(HashSet<With<LabelString>>),
     /// This error occurs when a label is defined more than once.
@@ -47,65 +47,65 @@ where
     }
 }
 
-impl Display for CFGError {
+impl Display for CfgError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CFGError::LabelsNotDefined(labels) => {
+            CfgError::LabelsNotDefined(labels) => {
                 write!(f, "Labels not defined: {}", labels.as_str_list())
             }
-            CFGError::DuplicateLabel(label) => {
+            CfgError::DuplicateLabel(label) => {
                 write!(f, "Duplicate label: {label}")
             }
-            CFGError::MultipleLabelsForReturn(_, labels) => {
+            CfgError::MultipleLabelsForReturn(_, labels) => {
                 write!(f, "Multiple labels for return: {}", labels.as_str_list())
             }
-            CFGError::NoLabelForReturn(_) => {
+            CfgError::NoLabelForReturn(_) => {
                 write!(f, "No label for return")
             }
-            CFGError::UnexpectedError => write!(f, "Unexpected error"),
-            CFGError::AssertionError => write!(f, "Assertion error"),
+            CfgError::UnexpectedError => write!(f, "Unexpected error"),
+            CfgError::AssertionError => write!(f, "Assertion error"),
         }
     }
 }
 
-impl From<&CFGError> for WarningLevel {
-    fn from(value: &CFGError) -> Self {
+impl From<&CfgError> for WarningLevel {
+    fn from(value: &CfgError) -> Self {
         match value {
-            CFGError::LabelsNotDefined(_)
-            | CFGError::DuplicateLabel(_)
-            | CFGError::MultipleLabelsForReturn(_, _)
-            | CFGError::NoLabelForReturn(_)
-            | CFGError::UnexpectedError
-            | CFGError::AssertionError => WarningLevel::Error,
+            CfgError::LabelsNotDefined(_)
+            | CfgError::DuplicateLabel(_)
+            | CfgError::MultipleLabelsForReturn(_, _)
+            | CfgError::NoLabelForReturn(_)
+            | CfgError::UnexpectedError
+            | CfgError::AssertionError => WarningLevel::Error,
         }
     }
 }
 
-impl DiagnosticLocation for CFGError {
+impl DiagnosticLocation for CfgError {
     fn file(&self) -> uuid::Uuid {
         match self {
-            CFGError::MultipleLabelsForReturn(node, _) | CFGError::NoLabelForReturn(node) => {
+            CfgError::MultipleLabelsForReturn(node, _) | CfgError::NoLabelForReturn(node) => {
                 node.file()
             }
-            CFGError::LabelsNotDefined(labels) => labels.iter().next().unwrap().file(),
-            CFGError::DuplicateLabel(label) => label.file(),
-            CFGError::UnexpectedError | CFGError::AssertionError => uuid::Uuid::nil(),
+            CfgError::LabelsNotDefined(labels) => labels.iter().next().unwrap().file(),
+            CfgError::DuplicateLabel(label) => label.file(),
+            CfgError::UnexpectedError | CfgError::AssertionError => uuid::Uuid::nil(),
         }
     }
 
     fn range(&self) -> crate::parser::Range {
         match self {
-            CFGError::MultipleLabelsForReturn(node, _) | CFGError::NoLabelForReturn(node) => {
+            CfgError::MultipleLabelsForReturn(node, _) | CfgError::NoLabelForReturn(node) => {
                 node.range()
             }
-            CFGError::LabelsNotDefined(labels) => labels.iter().next().unwrap().range(),
-            CFGError::DuplicateLabel(label) => label.range(),
-            CFGError::UnexpectedError | CFGError::AssertionError => crate::parser::Range::default(),
+            CfgError::LabelsNotDefined(labels) => labels.iter().next().unwrap().range(),
+            CfgError::DuplicateLabel(label) => label.range(),
+            CfgError::UnexpectedError | CfgError::AssertionError => crate::parser::Range::default(),
         }
     }
 }
 
-impl DiagnosticMessage for CFGError {
+impl DiagnosticMessage for CfgError {
     fn related(&self) -> Option<Vec<super::RelatedDiagnosticItem>> {
         None
     }
@@ -121,14 +121,14 @@ impl DiagnosticMessage for CFGError {
     }
     fn long_description(&self) -> String {
         match self {
-            CFGError::DuplicateLabel(label) => format!(
+            CfgError::DuplicateLabel(label) => format!(
                 "The label {label} is defined more than once. Labels must be unique."
             ),
-            CFGError::LabelsNotDefined(labels) => format!(
+            CfgError::LabelsNotDefined(labels) => format!(
                 "The labels {} are used but not defined. Labels must be defined within your file.",
                 labels.as_str_list()
             ),
-            CFGError::MultipleLabelsForReturn(_, labels) => format!(
+            CfgError::MultipleLabelsForReturn(_, labels) => format!(
                 "The return statement can be reached by multiple function labels: {}.\n\n\
                 Every return statement should only be reachable by one label. This also ensures\
                 that every instruction is reachable by only one label and is ever only part of a single function.\n\n\
@@ -138,7 +138,7 @@ impl DiagnosticMessage for CFGError {
                 for each function.",
                 labels.as_str_list()
             ),
-            CFGError::NoLabelForReturn(_) => "The return statement can be reached by no function labels.\n\n\
+            CfgError::NoLabelForReturn(_) => "The return statement can be reached by no function labels.\n\n\
                 Every return statement should be reachable by one label. This also ensures\
                 that every instruction is reachable by only one label and is ever only part of a single function.\n\n\
                 This return statement might be placed in code that isn't in a function. For example, you might have a
@@ -147,8 +147,8 @@ impl DiagnosticMessage for CFGError {
                 A label is considered a function if it has been called by a [jal] instruction. This code might also be\
                 missing from your file or imports.
                 ".to_string(),
-            CFGError::UnexpectedError => "An unexpected error occurred. Please file a bug.".to_string(),
-            CFGError::AssertionError => "An unexpected assertion error occurred. Please file a bug.".to_string(),
+            CfgError::UnexpectedError => "An unexpected error occurred. Please file a bug.".to_string(),
+            CfgError::AssertionError => "An unexpected assertion error occurred. Please file a bug.".to_string(),
         }
     }
 }

--- a/riscv_analysis/src/passes/manager.rs
+++ b/riscv_analysis/src/passes/manager.rs
@@ -13,7 +13,7 @@ use crate::{
     parser::ParserNode,
 };
 
-use super::{CFGError, GenerationPass, LintError, LintPass};
+use super::{CfgError, GenerationPass, LintError, LintPass};
 
 #[derive(Default)]
 pub struct DebugInfo {
@@ -23,7 +23,7 @@ pub struct DebugInfo {
 
 pub struct Manager;
 impl Manager {
-    pub fn gen_full_cfg(cfg: Vec<ParserNode>) -> Result<Cfg, Box<CFGError>> {
+    pub fn gen_full_cfg(cfg: Vec<ParserNode>) -> Result<Cfg, Box<CfgError>> {
         let mut cfg = Cfg::new(cfg)?;
 
         NodeDirectionPass::run(&mut cfg)?;
@@ -49,7 +49,7 @@ impl Manager {
         CalleeSavedGarbageReadCheck::run(cfg, errors);
         LostCalleeSavedRegisterCheck::run(cfg, errors);
     }
-    pub fn run(cfg: Vec<ParserNode>) -> Result<Vec<LintError>, Box<CFGError>> {
+    pub fn run(cfg: Vec<ParserNode>) -> Result<Vec<LintError>, Box<CfgError>> {
         let mut errors = Vec::new();
         let cfg = Self::gen_full_cfg(cfg)?;
         Self::run_diagnostics(&cfg, &mut errors);

--- a/riscv_analysis/src/passes/pass.rs
+++ b/riscv_analysis/src/passes/pass.rs
@@ -1,13 +1,13 @@
 use crate::cfg::Cfg;
 
-use super::{CFGError, LintError};
+use super::{CfgError, LintError};
 
 pub trait GenerationPass {
-    fn run(cfg: &mut Cfg) -> Result<(), Box<CFGError>>;
+    fn run(cfg: &mut Cfg) -> Result<(), Box<CfgError>>;
 }
 
 pub trait AssertionPass {
-    fn run(cfg: &Cfg) -> Result<(), Box<CFGError>>;
+    fn run(cfg: &Cfg) -> Result<(), Box<CfgError>>;
 }
 
 pub trait LintPass {

--- a/riscv_analysis_cli/src/main.rs
+++ b/riscv_analysis_cli/src/main.rs
@@ -337,7 +337,7 @@ fn main() {
                 Ok(full_cfg) => {
                     // if debug, print out the cfg
                     if lint.yaml {
-                        let wrapped = riscv_analysis::cfg::CFGWrapper::from(&full_cfg);
+                        let wrapped = riscv_analysis::cfg::CfgWrapper::from(&full_cfg);
                         println!("{}", serde_yaml::to_string(&wrapped).unwrap());
                     } else if lint.debug {
                         println!("{}", full_cfg);
@@ -407,8 +407,8 @@ fn main() {
 mod tests {
 
     use crate::IOFileReader;
-    use riscv_analysis::cfg::CFGWrapper;
     use riscv_analysis::cfg::Cfg;
+    use riscv_analysis::cfg::CfgWrapper;
     use riscv_analysis::parser::RVParser;
     use riscv_analysis::passes::Manager;
 
@@ -430,15 +430,15 @@ mod tests {
                 let parsed = parser.parse(filename, false);
 
                 let res: Cfg = Manager::gen_full_cfg(parsed.0).unwrap();
-                let res = CFGWrapper::from(&res);
+                let res = CfgWrapper::from(&res);
 
                 // deserialize the yaml file
                 let compare = std::fs::read_to_string(compare).unwrap();
-                let compare: CFGWrapper = serde_yaml::from_str(&compare).unwrap();
+                let compare: CfgWrapper = serde_yaml::from_str(&compare).unwrap();
 
                 // read the res into yaml format to match
                 let res = serde_yaml::to_string(&res).unwrap();
-                let res: CFGWrapper = serde_yaml::from_str(&res).unwrap();
+                let res: CfgWrapper = serde_yaml::from_str(&res).unwrap();
 
                 assert_eq!(res, compare);
             }


### PR DESCRIPTION
Summary: This PR renames all symbols that begin with `CFG` to `Cfg`. This is done for consistency.

Test plan: Since this is a variable renaming, this will not affect any of the tests or introduce any new code. Existing tests should pass normally