### PR TITLE
[RV-15] feat: add tokens for comment fields

### DIFF
--- a/riscv_analysis/src/parser/lexer.rs
+++ b/riscv_analysis/src/parser/lexer.rs
@@ -293,6 +293,12 @@ mod tests {
     }
 
     #[test]
+    fn lex_directive() {
+        let tokens = tokenize(".text");
+        assert_eq!(tokens, vec![Token::Directive("text".to_owned())]);
+    }
+
+    #[test]
     fn lex_instruction() {
         let tokens = tokenize("add s0, s0, s2");
         assert_eq!(

--- a/riscv_analysis/src/parser/lexer.rs
+++ b/riscv_analysis/src/parser/lexer.rs
@@ -276,9 +276,14 @@ impl Iterator for Lexer {
 #[cfg(test)]
 mod tests {
 
-    use crate::parser::{Info, Lexer, Token};
-    fn tokenize<S: Into<String>>(input: S) -> Vec<Info> {
-        Lexer::new(input, uuid::Uuid::nil()).collect()
+    // TODO: These tests only test the token output, but not the ranges or the
+    // IDs of the file. Those need to be tested and documented.
+
+    use crate::parser::{Lexer, Token};
+    fn tokenize<S: Into<String>>(input: S) -> Vec<Token> {
+        Lexer::new(input, uuid::Uuid::nil())
+            .map(|x| x.token)
+            .collect()
     }
 
     #[test]
@@ -358,10 +363,7 @@ mod tests {
         );
 
         assert_eq!(
-            lexer
-                .iter()
-                .map(|t| t.token.clone())
-                .collect::<Vec<Token>>(),
+            lexer,
             vec![
                 Token::Symbol("add".into()),
                 Token::Symbol("x2".into()),

--- a/riscv_analysis/src/parser/lexer.rs
+++ b/riscv_analysis/src/parser/lexer.rs
@@ -417,14 +417,15 @@ mod tests {
     }
 
     #[test]
-    fn lex_comments() {
+    fn lex_all_tokens() {
         let lexer = tokenize(
-            "add x2,x2,x3 # hello, world!@#DKSAOKLJu3iou12o\nBLCOK:\n\n\nsub a0 a0 a1\nmy_block: add s0, s0, s2\nadd s0, s0, s2",
+            ".text add x2,x2,x3 # hello, world!@#DKSAOKLJu3iou12o\nBLCOK:\n\n\nsub a0 a0 a1\nmy_block: add s0, s0, s2\nadd s0, s0, s2",
         );
 
         assert_eq!(
             lexer,
             vec![
+                Token::Directive("text".to_string()),
                 Token::Symbol("add".into()),
                 Token::Symbol("x2".into()),
                 Token::Symbol("x2".into()),

--- a/riscv_analysis/src/parser/lexer.rs
+++ b/riscv_analysis/src/parser/lexer.rs
@@ -130,6 +130,9 @@ impl Iterator for Lexer {
     fn next(&mut self) -> Option<Self::Item> {
         self.skip_ws();
 
+        // TODO(rajan): ensure that we are consistent with whether the tokens are included or not in the Token representation
+        // TODO(rajan): should we introduce a new token type for the comment hash (#) and directive hash (.)?
+
         match self.ch {
             '\n' => {
                 let pos = self.get_range();
@@ -188,19 +191,27 @@ impl Iterator for Lexer {
                 })
             }
             '#' => {
-                // skip line till newline
+                // Convert comments to token
+
+                let start = self.get_pos();
+                self.next_char();
+
+                let mut comment_str: String = String::new();
+
                 while self.ch != '\n' && self.ch != EOF_CONST {
+                    comment_str += &self.ch.to_string();
                     self.next_char();
                 }
 
-                if self.ch == EOF_CONST {
-                    return None;
-                }
-                self.next_char();
+                let end = self.get_pos();
+
+                // Empty comment strings are allowed, in the case of a
+                // comment with a new line. We don't strip any whitespace
+                // for comments here.
 
                 Some(Info {
-                    token: Token::Newline,
-                    pos: self.get_range(),
+                    token: Token::Comment(comment_str.clone()),
+                    pos: Range { start, end },
                     file: self.source_id,
                 })
             }
@@ -293,6 +304,49 @@ mod tests {
     }
 
     #[test]
+    fn lex_comment() {
+        let tokens = tokenize("# comments are needed");
+        assert_eq!(
+            tokens,
+            vec![Token::Comment(" comments are needed".to_owned())]
+        );
+    }
+
+    #[test]
+    fn lex_comments_with_differing_whitespaces() {
+        let tokens =
+            tokenize("#\n#\n# new line comments  with lots of \t whitespace and other special .text characters is allowed  jal ra, x0   \n\n  #.text\n#li a0, 0");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Comment("".to_owned()),
+                Token::Newline,
+                Token::Comment("".to_owned()),
+                Token::Newline,
+                Token::Comment(" new line comments  with lots of \t whitespace and other special .text characters is allowed  jal ra, x0   ".to_owned()),
+                Token::Newline,
+                Token::Newline,
+                Token::Comment(".text".to_owned()),
+                Token::Newline,
+                Token::Comment("li a0, 0".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn lex_empty_comment_as_final_character() {
+        let tokens = tokenize("#this is a comment\n#");
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Comment("this is a comment".to_owned()),
+                Token::Newline,
+                Token::Comment("".to_owned()),
+            ]
+        )
+    }
+
+    #[test]
     fn lex_directive() {
         let tokens = tokenize(".text");
         assert_eq!(tokens, vec![Token::Directive("text".to_owned())]);
@@ -375,6 +429,7 @@ mod tests {
                 Token::Symbol("x2".into()),
                 Token::Symbol("x2".into()),
                 Token::Symbol("x3".into()),
+                Token::Comment(" hello, world!@#DKSAOKLJu3iou12o".to_string()),
                 Token::Newline,
                 Token::Label("BLCOK".to_string()),
                 Token::Newline,

--- a/riscv_analysis/src/parser/parsing.rs
+++ b/riscv_analysis/src/parser/parsing.rs
@@ -1033,6 +1033,9 @@ impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
             Token::LParen | Token::RParen | Token::String(_) => {
                 Err(LexError::UnexpectedToken(next_node))
             }
+            // Skip comment token
+            Token::Comment(_) => Err(LexError::Ignored(next_node))
+
         }
     }
 }

--- a/riscv_analysis/src/parser/token.rs
+++ b/riscv_analysis/src/parser/token.rs
@@ -74,6 +74,11 @@ pub enum Token {
     Directive(String),
     /// String: text enclosed in double quotes
     String(String),
+    /// Comment: text starting with # up until the first newline.
+    /// A comment is a line of text that is ignored by
+    /// the assembler, but they are useful for human readers.
+    /// They may be used to annotate the assembler in the future.
+    Comment(String),
 }
 
 impl Token {
@@ -87,6 +92,7 @@ impl Token {
             Token::Symbol(s) => s.clone(),
             Token::Directive(d) => format!(".{d}"),
             Token::String(s) => format!("\"{s}\""),
+            Token::Comment(c) => format!("#{c}:"),
         }
     }
 }
@@ -216,6 +222,7 @@ impl Display for Token {
             Token::Symbol(s) => write!(f, "SYMBOL({s})"),
             Token::Directive(s) => write!(f, "DIRECTIVE({s})"),
             Token::String(s) => write!(f, "STRING({s})"),
+            Token::Comment(s) => write!(f, "COMMENT{s}"),
             Token::Newline => write!(f, "NEWLINE"),
             Token::LParen => write!(f, "LPAREN"),
             Token::RParen => write!(f, "RPAREN"),


### PR DESCRIPTION
Summary: This PR adds tokens for comments. The tokens contain the text of the comments, which can be used to annotate the output of the RISC-V analyzer in the future.

Test plan: 3 unit tests were added for tokenizing comments, including cases with the end of file and other tokens within comments. This is to ensure that tokenizing does not happen within comments.