### PR TITLE
[RV-19] refactor: use MemoryLocation over raw i32 to represent stack locations

### DIFF
--- a/riscv_analysis/src/analysis/gen_kill.rs
+++ b/riscv_analysis/src/analysis/gen_kill.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::parser::{IArithType, ParserNode, RegSets, Register};
 
-use super::AvailableValue;
+use super::{AvailableValue, MemoryLocation};
 
 impl ParserNode {
     #[must_use]
@@ -46,12 +46,12 @@ impl ParserNode {
     }
 
     #[must_use]
-    pub fn gen_stack_value(&self) -> Option<(i32, AvailableValue)> {
+    pub fn gen_stack_value(&self) -> Option<(MemoryLocation, AvailableValue)> {
         match self {
             ParserNode::Store(expr) => {
                 if expr.rs1 == Register::X2 {
                     Some((
-                        expr.imm.data.0,
+                        MemoryLocation::StackOffset(expr.imm.data.0),
                         AvailableValue::RegisterWithScalar(expr.rs2.data, 0),
                     ))
                 } else {

--- a/riscv_analysis/src/analysis/gen_kill.rs
+++ b/riscv_analysis/src/analysis/gen_kill.rs
@@ -46,7 +46,7 @@ impl ParserNode {
     }
 
     #[must_use]
-    pub fn gen_stack_value(&self) -> Option<(MemoryLocation, AvailableValue)> {
+    pub fn gen_memory_value(&self) -> Option<(MemoryLocation, AvailableValue)> {
         match self {
             ParserNode::Store(expr) => {
                 if expr.rs1 == Register::X2 {

--- a/riscv_analysis/src/analysis/memory_location.rs
+++ b/riscv_analysis/src/analysis/memory_location.rs
@@ -1,0 +1,101 @@
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Serialize, Serializer};
+use std::fmt;
+
+/// A memory location.
+///
+/// This is used to represent a memory location.
+///
+/// Memory locations with relativity are always relative
+/// from the entry point of a function. One consequence
+/// is that multiple memory locations can have the same
+/// offset. In other terms, equality across memory
+/// contexts is not guaranteed.
+///
+/// The teminology used is as follows:
+/// - `sp_i` is the stack pointer at the beginning of the function.
+#[derive(Debug, PartialEq, Clone, Eq, Hash, PartialOrd, Ord)]
+pub enum MemoryLocation {
+    /// Offset from the stack pointer (sp) at the beginning of the function.
+    ///
+    /// The stack location offset is the offset added to the
+    /// stack pointer to get a specific available value. For example,
+    /// the integer `-8` will map to the value at address `sp - 8`.
+    ///
+    /// The stack pointer is always referring to the stack pointer
+    /// value at the beginning of the function body.
+    ///
+    /// In the current implementation, only 32-bit values are
+    /// kept track of on the stack. This is because the register
+    /// is 32-bit.
+    StackOffset(i32),
+}
+
+impl Serialize for MemoryLocation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            MemoryLocation::StackOffset(i) => serializer.serialize_str(&format!(
+                "so{}{}",
+                if i < &0 { "-" } else { "+" },
+                i.abs()
+            )),
+        }
+    }
+}
+
+struct MemoryLocationVisitor;
+
+impl<'de> Visitor<'de> for MemoryLocationVisitor {
+    type Value = MemoryLocation;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a memory location custom representation")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if let Some(so) = v.strip_prefix("so") {
+            let (sign, num) = so.split_at(1);
+            let num = num.parse::<i32>().map_err(de::Error::custom)?;
+            Ok(MemoryLocation::StackOffset(if sign == "-" {
+                -num
+            } else {
+                num
+            }))
+        } else {
+            Err(de::Error::custom("invalid memory location"))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MemoryLocation {
+    fn deserialize<D>(deserializer: D) -> Result<MemoryLocation, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(MemoryLocationVisitor)
+    }
+}
+
+// TODO: Introduce a "Function" field for `MemoryLocation::StackOffset`. This way, we
+// can track the exact stack pointer offset for each function.
+
+impl std::fmt::Display for MemoryLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // sp_i == "stack pointer at the beginning of the function, or initial"
+        match self {
+            MemoryLocation::StackOffset(offset) => {
+                if offset < &0 {
+                    write!(f, "sp_i - {}", offset.abs())
+                } else {
+                    write!(f, "sp_i + {offset}")
+                }
+            }
+        }
+    }
+}

--- a/riscv_analysis/src/analysis/mod.rs
+++ b/riscv_analysis/src/analysis/mod.rs
@@ -10,3 +10,5 @@ mod set_traits;
 pub use set_traits::*;
 
 mod display;
+
+mod memory_location;

--- a/riscv_analysis/src/analysis/mod.rs
+++ b/riscv_analysis/src/analysis/mod.rs
@@ -12,3 +12,4 @@ pub use set_traits::*;
 mod display;
 
 mod memory_location;
+pub use memory_location::*;

--- a/riscv_analysis/src/analysis/set_traits.rs
+++ b/riscv_analysis/src/analysis/set_traits.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 
 use crate::parser::Register;
 
-use super::AvailableValue;
+use super::{AvailableValue, MemoryLocation};
 
 pub trait CustomIntersection {
     #[must_use]
@@ -145,18 +145,19 @@ impl CustomUnion<i32> for i32 {
     }
 }
 
-impl<S> CustomUnionFilterMap<Option<(i32, AvailableValue)>, (i32, AvailableValue)>
-    for HashMap<i32, AvailableValue, S>
+impl<S>
+    CustomUnionFilterMap<Option<(MemoryLocation, AvailableValue)>, (MemoryLocation, AvailableValue)>
+    for HashMap<MemoryLocation, AvailableValue, S>
 where
     S: std::hash::BuildHasher + Default + Clone,
 {
-    fn union_filter_map<F>(&self, other: &Option<(i32, AvailableValue)>, f: F) -> Self
+    fn union_filter_map<F>(&self, other: &Option<(MemoryLocation, AvailableValue)>, f: F) -> Self
     where
-        F: Fn(&(i32, AvailableValue)) -> Option<(i32, AvailableValue)>,
+        F: Fn(&(MemoryLocation, AvailableValue)) -> Option<(MemoryLocation, AvailableValue)>,
     {
         let mut out = self.clone();
         if let Some((off, val)) = other {
-            if let Some((new_off, new_val)) = f(&(*off, val.clone())) {
+            if let Some((new_off, new_val)) = f(&(off.clone(), val.clone())) {
                 out.insert(new_off, new_val);
             }
         }

--- a/riscv_analysis/src/cfg/display.rs
+++ b/riscv_analysis/src/cfg/display.rs
@@ -48,7 +48,7 @@ impl Display for CfgNode {
         f.write_fmt(format_args!("  | VALO | {}\n", self.reg_values_out().str()))?;
         f.write_fmt(format_args!(
             "  | STCK | {}\n",
-            self.stack_values_out().str()
+            self.memory_values_out().str()
         ))?;
         f.write_fmt(format_args!("  | UDEF | {}\n", self.u_def().str()))?;
         f.write_fmt(format_args!("  | NEXT | {}\n", self.nexts().len()))?;

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -50,11 +50,11 @@ pub struct CfgNode {
     /// Map each memory location to the available value
     /// that is set before the instruction represented by this
     /// CFG node is run.
-    stack_values_in: RefCell<HashMap<MemoryLocation, AvailableValue>>,
+    memory_values_in: RefCell<HashMap<MemoryLocation, AvailableValue>>,
     /// Map each memory location to the available value
     /// that is set after the instruction represented by this
     /// CFG node is run.
-    stack_values_out: RefCell<HashMap<MemoryLocation, AvailableValue>>,
+    memory_values_out: RefCell<HashMap<MemoryLocation, AvailableValue>>,
     /// The set of registers that are live before the instruction
     /// represented by this CFG node is run.
     live_in: RefCell<HashSet<Register>>,
@@ -92,8 +92,8 @@ impl CfgNode {
             function: RefCell::new(None),
             reg_values_in: RefCell::new(HashMap::new()),
             reg_values_out: RefCell::new(HashMap::new()),
-            stack_values_in: RefCell::new(HashMap::new()),
-            stack_values_out: RefCell::new(HashMap::new()),
+            memory_values_in: RefCell::new(HashMap::new()),
+            memory_values_out: RefCell::new(HashMap::new()),
             live_in: RefCell::new(HashSet::new()),
             live_out: RefCell::new(HashSet::new()),
             u_def: RefCell::new(HashSet::new()),
@@ -140,20 +140,20 @@ impl CfgNode {
         *self.reg_values_out.borrow_mut() = available_out;
     }
 
-    pub fn stack_values_in(&self) -> HashMap<MemoryLocation, AvailableValue> {
-        self.stack_values_in.borrow().clone()
+    pub fn memory_values_in(&self) -> HashMap<MemoryLocation, AvailableValue> {
+        self.memory_values_in.borrow().clone()
     }
 
-    pub fn set_stack_values_in(&self, stack_in: HashMap<MemoryLocation, AvailableValue>) {
-        *self.stack_values_in.borrow_mut() = stack_in;
+    pub fn set_memory_values_in(&self, memory_in: HashMap<MemoryLocation, AvailableValue>) {
+        *self.memory_values_in.borrow_mut() = memory_in;
     }
 
-    pub fn stack_values_out(&self) -> HashMap<MemoryLocation, AvailableValue> {
-        self.stack_values_out.borrow().clone()
+    pub fn memory_values_out(&self) -> HashMap<MemoryLocation, AvailableValue> {
+        self.memory_values_out.borrow().clone()
     }
 
-    pub fn set_stack_values_out(&self, stack_out: HashMap<MemoryLocation, AvailableValue>) {
-        *self.stack_values_out.borrow_mut() = stack_out;
+    pub fn set_memory_values_out(&self, memory_out: HashMap<MemoryLocation, AvailableValue>) {
+        *self.memory_values_out.borrow_mut() = memory_out;
     }
 
     pub fn live_in(&self) -> HashSet<Register> {

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -1,4 +1,5 @@
 use crate::analysis::AvailableValue;
+use crate::analysis::MemoryLocation;
 use crate::parser::LabelString;
 use crate::parser::ParserNode;
 use crate::parser::Register;
@@ -46,36 +47,14 @@ pub struct CfgNode {
     /// values. This means that many values might be duplicated above
     /// and below this CFG node.
     reg_values_out: RefCell<HashMap<Register, AvailableValue>>,
-    /// Map each stack location offset to the available value
+    /// Map each memory location to the available value
     /// that is set before the instruction represented by this
     /// CFG node is run.
-    ///
-    /// The stack location offset is the offset added to the
-    /// stack pointer to get a specific available value. For example,
-    /// the integer `-8` will map to the value at address `sp - 8`.
-    ///
-    /// The stack pointer is always referring to the stack pointer
-    /// value at the beginning of the function body.
-    ///
-    /// In the current implementation, only 32-bit values are
-    /// kept track of on the stack. This is because the register
-    /// is 32-bit.
-    stack_values_in: RefCell<HashMap<i32, AvailableValue>>,
-    /// Map each stack location offset to the available value
+    stack_values_in: RefCell<HashMap<MemoryLocation, AvailableValue>>,
+    /// Map each memory location to the available value
     /// that is set after the instruction represented by this
     /// CFG node is run.
-    ///
-    /// The stack location offset is the offset added to the
-    /// stack pointer to get a specific available value. For example,
-    /// the integer `-8` will map to the value at address `sp - 8`.
-    ///
-    /// The stack pointer is always referring to the stack pointer
-    /// value at the beginning of the function body.
-    ///
-    /// In the current implementation, only 32-bit values are
-    /// kept track of on the stack. This is because the register
-    /// is 32-bit.
-    stack_values_out: RefCell<HashMap<i32, AvailableValue>>,
+    stack_values_out: RefCell<HashMap<MemoryLocation, AvailableValue>>,
     /// The set of registers that are live before the instruction
     /// represented by this CFG node is run.
     live_in: RefCell<HashSet<Register>>,
@@ -161,19 +140,19 @@ impl CfgNode {
         *self.reg_values_out.borrow_mut() = available_out;
     }
 
-    pub fn stack_values_in(&self) -> HashMap<i32, AvailableValue> {
+    pub fn stack_values_in(&self) -> HashMap<MemoryLocation, AvailableValue> {
         self.stack_values_in.borrow().clone()
     }
 
-    pub fn set_stack_values_in(&self, stack_in: HashMap<i32, AvailableValue>) {
+    pub fn set_stack_values_in(&self, stack_in: HashMap<MemoryLocation, AvailableValue>) {
         *self.stack_values_in.borrow_mut() = stack_in;
     }
 
-    pub fn stack_values_out(&self) -> HashMap<i32, AvailableValue> {
+    pub fn stack_values_out(&self) -> HashMap<MemoryLocation, AvailableValue> {
         self.stack_values_out.borrow().clone()
     }
 
-    pub fn set_stack_values_out(&self, stack_out: HashMap<i32, AvailableValue>) {
+    pub fn set_stack_values_out(&self, stack_out: HashMap<MemoryLocation, AvailableValue>) {
         *self.stack_values_out.borrow_mut() = stack_out;
     }
 

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -53,13 +53,13 @@ pub struct NodeWrapper {
         skip_serializing_if = "HashMap::is_empty",
         serialize_with = "sorted_map"
     )]
-    pub stack_values_in: HashMap<MemoryLocation, AvailableValue>,
+    pub memory_values_in: HashMap<MemoryLocation, AvailableValue>,
     #[serde(
         default,
         skip_serializing_if = "HashMap::is_empty",
         serialize_with = "sorted_map"
     )]
-    pub stack_values_out: HashMap<MemoryLocation, AvailableValue>,
+    pub memory_values_out: HashMap<MemoryLocation, AvailableValue>,
     #[serde(
         default,
         skip_serializing_if = "HashSet::is_empty",
@@ -119,8 +119,8 @@ impl NodeWrapper {
                 .collect(),
             reg_values_in: node.reg_values_in(),
             reg_values_out: node.reg_values_out(),
-            stack_values_in: node.stack_values_in(),
-            stack_values_out: node.stack_values_out(),
+            memory_values_in: node.memory_values_in(),
+            memory_values_out: node.memory_values_out(),
             live_in: node.live_in(),
             live_out: node.live_out(),
             u_def: node.u_def(),

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::{
-    analysis::AvailableValue,
+    analysis::{AvailableValue, MemoryLocation},
     parser::{ParserNode, Register},
 };
 
@@ -53,13 +53,13 @@ pub struct NodeWrapper {
         skip_serializing_if = "HashMap::is_empty",
         serialize_with = "sorted_map"
     )]
-    pub stack_values_in: HashMap<i32, AvailableValue>,
+    pub stack_values_in: HashMap<MemoryLocation, AvailableValue>,
     #[serde(
         default,
         skip_serializing_if = "HashMap::is_empty",
         serialize_with = "sorted_map"
     )]
-    pub stack_values_out: HashMap<i32, AvailableValue>,
+    pub stack_values_out: HashMap<MemoryLocation, AvailableValue>,
     #[serde(
         default,
         skip_serializing_if = "HashSet::is_empty",

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -379,7 +379,7 @@ impl LintPass for LostCalleeSavedRegisterCheck {
                         let mut found = false;
 
                         // check stack values:
-                        let stack = node.stack_values_out();
+                        let stack = node.memory_values_out();
                         for (_, val) in stack {
                             if let AvailableValue::OriginalRegisterWithScalar(reg2, offset) = val {
                                 if reg2 == reg.data && offset == 0 {

--- a/riscv_analysis_cli/resources/test/loop_check/raw.yaml
+++ b/riscv_analysis_cli/resources/test/loop_check/raw.yaml
@@ -528,8 +528,8 @@
     27: !ors
     - 27
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -660,12 +660,12 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -791,12 +791,12 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -919,12 +919,12 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -1045,15 +1045,15 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -1171,18 +1171,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -8: !ors
+  memory_values_in:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -1300,18 +1300,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -8: !ors
+  memory_values_in:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -1432,18 +1432,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -8: !ors
+  memory_values_in:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -1564,18 +1564,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -8: !ors
+  memory_values_in:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -1698,18 +1698,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -8: !ors
+  memory_values_in:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -1835,18 +1835,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -8: !ors
+  memory_values_in:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -1973,18 +1973,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -8: !ors
+  memory_values_in:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -2110,18 +2110,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -8: !ors
+  memory_values_in:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -8: !ors
+  memory_values_out:
+    so-8: !ors
     - 9
     - 0
-    -4: !ors
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -2248,12 +2248,12 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -2378,12 +2378,12 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -2512,12 +2512,12 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 8
     - 0
   live_in:
@@ -2645,12 +2645,12 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 8
     - 0
   live_in:

--- a/riscv_analysis_cli/resources/test/treg/raw.yaml
+++ b/riscv_analysis_cli/resources/test/treg/raw.yaml
@@ -600,8 +600,8 @@
     27: !ors
     - 27
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 1
     - 0
   live_in:
@@ -736,15 +736,15 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 1
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
   live_in:
@@ -875,18 +875,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
   live_in:
@@ -1011,18 +1011,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
   live_in:
@@ -1147,18 +1147,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
   live_in:
@@ -1288,18 +1288,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
   live_in:
@@ -1433,18 +1433,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
   live_in:
@@ -1577,18 +1577,18 @@
     27: !ors
     - 27
     - 0
-  stack_values_in:
-    -4: !ors
+  memory_values_in:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
-  stack_values_out:
-    -4: !ors
+  memory_values_out:
+    so-4: !ors
     - 1
     - 0
-    0: !ors
+    so+0: !ors
     - 8
     - 0
   live_in:


### PR DESCRIPTION
**Summary**: This PR introduces a new type `MemoryLocation` as an abstract representation of memory. It currently has one variant `StackOffset`. This PR also replaces the use of raw `i32`s into this new type for better readability.

**Test plan**: `MemoryLocation` is currently only a wrapper type for `i32`, so it does not have any functionality. Thus, traditional tests should pass as they did before.