### PR TITLE
fix: VSCode extension build fails due to missing dependency

### DIFF
--- a/build-vsix.sh
+++ b/build-vsix.sh
@@ -1,9 +1,9 @@
 
-cd riscv_analysis_lsp
-wasm-pack build --target nodejs
-cd ..
-rm -rf lsp/server/pkg
-cp -r riscv_analysis_lsp/pkg lsp/server
-cd lsp
-vsce package
+cd riscv_analysis_lsp &&
+wasm-pack build --target nodejs &&
+cd .. &&
+rm -rf lsp/server/pkg &&
+cp -r riscv_analysis_lsp/pkg lsp/server &&
+cd lsp &&
+vsce package &&
 cd ..

--- a/lsp/client/package-lock.json
+++ b/lsp/client/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
+				"@types/node": "^20.14.10",
 				"vscode-languageclient": "^8.1.0"
 			},
 			"devDependencies": {
@@ -26,6 +27,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "20.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+			"dependencies": {
+				"undici-types": "~5.26.4"
 			}
 		},
 		"node_modules/@types/vscode": {
@@ -431,6 +440,11 @@
 				"node": "*"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+		},
 		"node_modules/unzipper": {
 			"version": "0.10.11",
 			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
@@ -527,6 +541,14 @@
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
+		},
+		"@types/node": {
+			"version": "20.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+			"requires": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"@types/vscode": {
 			"version": "1.75.1",
@@ -858,6 +880,11 @@
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
 			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
 			"dev": true
+		},
+		"undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"unzipper": {
 			"version": "0.10.11",

--- a/lsp/client/package.json
+++ b/lsp/client/package.json
@@ -1,5 +1,4 @@
 {
-
 	"name": "riscv-analysis-client",
 	"description": "RISC-V Assembly Language Server",
 	"author": "Rajan Maghera",
@@ -14,6 +13,7 @@
 		"vscode": "^1.75.0"
 	},
 	"dependencies": {
+		"@types/node": "^20.14.10",
 		"vscode-languageclient": "^8.1.0"
 	},
 	"devDependencies": {

--- a/lsp/server/package-lock.json
+++ b/lsp/server/package-lock.json
@@ -9,12 +9,26 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
+				"@types/node": "^20.14.10",
 				"vscode-languageserver": "^8.1.0",
 				"vscode-languageserver-textdocument": "^1.0.8"
 			},
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/@types/node": {
+			"version": "20.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"node_modules/vscode-jsonrpc": {
 			"version": "8.1.0",
@@ -56,6 +70,19 @@
 		}
 	},
 	"dependencies": {
+		"@types/node": {
+			"version": "20.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+			"requires": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+		},
 		"vscode-jsonrpc": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",

--- a/lsp/server/package.json
+++ b/lsp/server/package.json
@@ -13,6 +13,7 @@
 		"node": "*"
 	},
 	"dependencies": {
+		"@types/node": "^20.14.10",
 		"vscode-languageserver": "^8.1.0",
 		"vscode-languageserver-textdocument": "^1.0.8"
 	},


### PR DESCRIPTION
**Summary**: This PR fixes an issue with building the VSCode extension due to a missing dependency.

**Test plan**: N/A as VSCode extension testing is not in our current scope.
