### PR TITLE
[RV-11] chore: fix remaining clippy lints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
 	"typescript.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single",
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	}
 }

--- a/riscv_analysis/src/analysis/available.rs
+++ b/riscv_analysis/src/analysis/available.rs
@@ -310,19 +310,13 @@ fn rule_perform_math_ops(
 ) {
     if let Some(reg) = node.stores_to() {
         let lhs = match node {
-            ParserNode::Arith(expr) => available_in
-                .get(&expr.rs1.data)
-                .map(std::clone::Clone::clone),
-            ParserNode::IArith(expr) => available_in
-                .get(&expr.rs1.data)
-                .map(std::clone::Clone::clone),
+            ParserNode::Arith(expr) => available_in.get(&expr.rs1.data).cloned(),
+            ParserNode::IArith(expr) => available_in.get(&expr.rs1.data).cloned(),
             _ => None,
         };
 
         let rhs = match node {
-            ParserNode::Arith(expr) => available_in
-                .get(&expr.rs2.data)
-                .map(std::clone::Clone::clone),
+            ParserNode::Arith(expr) => available_in.get(&expr.rs2.data).cloned(),
             ParserNode::IArith(expr) => Some(AvailableValue::Constant(expr.imm.data.0)),
             _ => None,
         };

--- a/riscv_analysis/src/analysis/mod.rs
+++ b/riscv_analysis/src/analysis/mod.rs
@@ -5,10 +5,8 @@ mod available;
 pub use available::*;
 
 mod gen_kill;
-pub use gen_kill::*;
 
 mod set_traits;
 pub use set_traits::*;
 
 mod display;
-pub use display::*;

--- a/riscv_analysis/src/analysis/set_traits.rs
+++ b/riscv_analysis/src/analysis/set_traits.rs
@@ -1,24 +1,9 @@
 use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
 use std::hash::Hash;
 
 use crate::parser::Register;
 
 use super::AvailableValue;
-
-trait CustomDefault {
-    fn def() -> Self;
-}
-
-impl<U, T> CustomDefault for std::collections::hash_map::IntoIter<U, T>
-where
-    T: Eq + Hash + Clone,
-    U: Eq + Hash + Clone + Display,
-{
-    fn def() -> Self {
-        HashMap::new().into_iter()
-    }
-}
 
 pub trait CustomIntersection {
     #[must_use]

--- a/riscv_analysis/src/cfg/graph.rs
+++ b/riscv_analysis/src/cfg/graph.rs
@@ -29,6 +29,14 @@ impl IntoIterator for &Cfg {
     }
 }
 
+impl Cfg {
+    /// Get an iterator over the `Cfg` nodes.
+    #[must_use]
+    pub fn iter(&self) -> std::vec::IntoIter<Rc<CFGNode>> {
+        self.into_iter()
+    }
+}
+
 trait BaseCFGGen {
     fn call_names(&self) -> HashSet<With<LabelString>>;
     fn jump_names(&self) -> HashSet<With<LabelString>>;

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -29,7 +29,7 @@ pub struct CFGNode {
     /// If this CFG node is part of a function, which function
     /// is it part of?
     ///
-    /// Every CFG node can only ever be part of one function. 
+    /// Every CFG node can only ever be part of one function.
     /// We do not allow one node to be part of more than one.
     function: RefCell<Option<Rc<Function>>>,
     /// Map each register to the available value that is set before
@@ -46,7 +46,7 @@ pub struct CFGNode {
     /// values. This means that many values might be duplicated above
     /// and below this CFG node.
     reg_values_out: RefCell<HashMap<Register, AvailableValue>>,
-    /// Map each stack location offset to the available value 
+    /// Map each stack location offset to the available value
     /// that is set before the instruction represented by this
     /// CFG node is run.
     ///
@@ -61,7 +61,7 @@ pub struct CFGNode {
     /// kept track of on the stack. This is because the register
     /// is 32-bit.
     stack_values_in: RefCell<HashMap<i32, AvailableValue>>,
-    /// Map each stack location offset to the available value 
+    /// Map each stack location offset to the available value
     /// that is set after the instruction represented by this
     /// CFG node is run.
     ///
@@ -76,10 +76,10 @@ pub struct CFGNode {
     /// kept track of on the stack. This is because the register
     /// is 32-bit.
     stack_values_out: RefCell<HashMap<i32, AvailableValue>>,
-    /// The set of registers that are live before the instruction 
+    /// The set of registers that are live before the instruction
     /// represented by this CFG node is run.
     live_in: RefCell<HashSet<Register>>,
-    /// The set of registers that are live after the instruction 
+    /// The set of registers that are live after the instruction
     /// represented by this CFG node is run.
     live_out: RefCell<HashSet<Register>>,
     /// The set of registers that have unconditionally been set after
@@ -92,7 +92,7 @@ pub struct CFGNode {
     ///
     /// Unconditionally set registers must be set in every path. For example,
     /// if there is a divergent if-else branch and the target block sets a register,
-    /// that register will be contained in the u_def set at the end of the function
+    /// that register will be contained in the `u_def` set at the end of the function
     /// if it is also set in the fallthrough block.
     ///
     /// Unconditionally set registers are used to determine the set of registers

--- a/riscv_analysis/src/fix/mod.rs
+++ b/riscv_analysis/src/fix/mod.rs
@@ -1,12 +1,12 @@
 use std::rc::Rc;
 
-use itertools::Itertools;
-
 use crate::{
     cfg::{Cfg, Function},
     parser::{Position, Range},
     passes::DiagnosticLocation,
 };
+use itertools::Itertools;
+use std::fmt::Write;
 
 /// SUPPORT FOR STACK FIXES
 
@@ -77,15 +77,19 @@ pub fn fix_stack(func: &Rc<Function>) -> Vec<Manipulation> {
         count * 4,
         regs.iter()
             .enumerate()
-            .map(|(i, reg)| format!("sw {}, {}(sp)\n", reg, i * 4))
-            .collect::<String>()
+            .fold(String::new(), |mut out, (i, reg)| {
+                writeln!(out, "sw {}, {}(sp)", reg, i * 4).unwrap();
+                out
+            })
     );
     let exit_text = format!(
         "\n# restore from stack\n{}addi sp, sp, {}\n\n",
         regs.iter()
             .enumerate()
-            .map(|(i, reg)| format!("lw {}, {}(sp)\n", reg, i * 4))
-            .collect::<String>(),
+            .fold(String::new(), |mut out, (i, reg)| {
+                writeln!(out, "lw {}, {}(sp)", reg, i * 4).unwrap();
+                out
+            }),
         count * 4
     );
 

--- a/riscv_analysis/src/fix/mod.rs
+++ b/riscv_analysis/src/fix/mod.rs
@@ -13,6 +13,7 @@ use std::fmt::Write;
 /// On stack fix with an input function, we will:
 /// - insert stack updates to entry
 /// - find exit points of code, if there is one, insert stack updates
+///
 /// TODO if there are multiple exit points, convert to a single exit point by adding
 ///   a label in between
 

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -201,7 +201,7 @@ impl LintPass for ControlFlowCheck {
 pub struct EcallCheck;
 impl LintPass for EcallCheck {
     fn run(cfg: &Cfg, errors: &mut Vec<LintError>) {
-        for (_i, node) in cfg.clone().into_iter().enumerate() {
+        for node in cfg.clone().into_iter() {
             if node.node().is_ecall() && node.known_ecall().is_none() {
                 errors.push(LintError::UnknownEcall(node.node().clone()));
             }
@@ -304,7 +304,7 @@ impl LintPass for StackCheckPass {
 pub struct CalleeSavedGarbageReadCheck;
 impl LintPass for CalleeSavedGarbageReadCheck {
     fn run(cfg: &Cfg, errors: &mut Vec<LintError>) {
-        for (_i, node) in cfg.nodes.clone().into_iter().enumerate() {
+        for node in cfg.nodes.clone().into_iter() {
             for read in node.node().reads_from() {
                 // if the node uses a calle saved register but not a memory access and the value going in is the original value, then we are reading a garbage value
                 // DESIGN DECISION: we allow any memory accesses for calle saved registers

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -201,7 +201,7 @@ impl LintPass for ControlFlowCheck {
 pub struct EcallCheck;
 impl LintPass for EcallCheck {
     fn run(cfg: &Cfg, errors: &mut Vec<LintError>) {
-        for node in cfg.clone().into_iter() {
+        for node in &cfg.clone() {
             if node.node().is_ecall() && node.known_ecall().is_none() {
                 errors.push(LintError::UnknownEcall(node.node().clone()));
             }
@@ -304,7 +304,7 @@ impl LintPass for StackCheckPass {
 pub struct CalleeSavedGarbageReadCheck;
 impl LintPass for CalleeSavedGarbageReadCheck {
     fn run(cfg: &Cfg, errors: &mut Vec<LintError>) {
-        for node in cfg.nodes.clone().into_iter() {
+        for node in &cfg.nodes.clone() {
             for read in node.node().reads_from() {
                 // if the node uses a calle saved register but not a memory access and the value going in is the original value, then we are reading a garbage value
                 // DESIGN DECISION: we allow any memory accesses for calle saved registers

--- a/riscv_analysis/src/parser/mod.rs
+++ b/riscv_analysis/src/parser/mod.rs
@@ -29,7 +29,6 @@ mod error;
 pub use error::*;
 
 mod display;
-pub use display::*;
 
 mod data_eq_wrapper;
 pub use data_eq_wrapper::*;

--- a/riscv_analysis/src/parser/parsing.rs
+++ b/riscv_analysis/src/parser/parsing.rs
@@ -194,22 +194,22 @@ impl Info {
 
     fn as_reg(&self) -> Result<With<Register>, LexError> {
         With::<Register>::try_from(self.clone())
-            .map_err(|_| LexError::Expected(vec![ExpectedType::Register], self.clone()))
+            .map_err(|()| LexError::Expected(vec![ExpectedType::Register], self.clone()))
     }
 
     fn as_imm(&self) -> Result<With<Imm>, LexError> {
         With::<Imm>::try_from(self.clone())
-            .map_err(|_| LexError::Expected(vec![ExpectedType::Imm], self.clone()))
+            .map_err(|()| LexError::Expected(vec![ExpectedType::Imm], self.clone()))
     }
 
     fn as_label(&self) -> Result<With<LabelString>, LexError> {
         With::<LabelString>::try_from(self.clone())
-            .map_err(|_| LexError::Expected(vec![ExpectedType::Label], self.clone()))
+            .map_err(|()| LexError::Expected(vec![ExpectedType::Label], self.clone()))
     }
 
     fn as_csrimm(&self) -> Result<With<CSRImm>, LexError> {
         With::<CSRImm>::try_from(self.clone())
-            .map_err(|_| LexError::Expected(vec![ExpectedType::CSRImm], self.clone()))
+            .map_err(|()| LexError::Expected(vec![ExpectedType::CSRImm], self.clone()))
     }
 
     fn as_string(&self) -> Result<With<String>, LexError> {
@@ -897,7 +897,7 @@ impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
             }
             Token::Label(s) => Ok(ParserNode::new_label(
                 With::new(
-                    LabelString::from_str(s).map_err(|_| {
+                    LabelString::from_str(s).map_err(|()| {
                         LexError::Expected(vec![ExpectedType::Label], next_node.clone())
                     })?,
                     next_node,

--- a/riscv_analysis/src/parser/token.rs
+++ b/riscv_analysis/src/parser/token.rs
@@ -323,17 +323,3 @@ where
         self.data == *other
     }
 }
-
-trait TokenExpression {
-    fn debug_tokens(&self);
-}
-
-impl TokenExpression for Vec<Token> {
-    fn debug_tokens(&self) {
-        print!("Tokens: ");
-        for item in self {
-            print!("[{item}]");
-        }
-        println!();
-    }
-}

--- a/riscv_analysis/src/passes/diagnostics.rs
+++ b/riscv_analysis/src/passes/diagnostics.rs
@@ -43,11 +43,7 @@ impl Eq for DiagnosticItem {}
 
 impl PartialOrd for DiagnosticItem {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.file == other.file {
-            self.range.partial_cmp(&other.range)
-        } else {
-            None
-        }
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
This PR fixes the `cargo clippy` lint errors that exist in the main branch. With these changes, we would have a cleaner slate for the other PRs we want to merge in.