### PR TITLE
[RV-2] Top down function pass

### DIFF
--- a/riscv_analysis/src/analysis/liveness.rs
+++ b/riscv_analysis/src/analysis/liveness.rs
@@ -31,13 +31,13 @@ impl GenerationPass for LivenessPass {
                     // We take the union of the existing live_in to match multiple call sites
                     let func_exit_live_in = node
                         .live_out()
-                        .intersection_c(&func.exit.u_def())
-                        .union_c(&func.exit.live_in())
-                        .union_c(&func.exit.node().gen_reg());
+                        .intersection_c(&func.exit().u_def())
+                        .union_c(&func.exit().live_in())
+                        .union_c(&func.exit().node().gen_reg());
 
-                    if func_exit_live_in != func.exit.live_in() {
+                    if func_exit_live_in != func.exit().live_in() {
                         changed = true;
-                        func.exit.set_live_in(func_exit_live_in.clone());
+                        func.exit().set_live_in(func_exit_live_in.clone());
                     }
 
                     // u_def[n] = (AND u_def[s] for all s in prev[n]) - kill[n] | (u_def[F_exit] AND return-registers)
@@ -58,7 +58,7 @@ impl GenerationPass for LivenessPass {
                         .reduce(|acc, x| acc.intersection_c(&x))
                         .unwrap_or_default()
                         .difference_c(&RegSets::caller_saved())
-                        .union_c(&(func.exit.u_def().intersection_c(&RegSets::ret())));
+                        .union_c(&(func.exit().u_def().intersection_c(&RegSets::ret())));
 
                     // live_in[n] = (live_in[F] & argument-registers) U (live_out[n] - kill[n])
                     // kill[n] = caller-saved

--- a/riscv_analysis/src/analysis/liveness.rs
+++ b/riscv_analysis/src/analysis/liveness.rs
@@ -64,7 +64,7 @@ impl GenerationPass for LivenessPass {
                     // kill[n] = caller-saved
                     let live_in_temp = node.live_out().difference_c(&RegSets::caller_saved());
                     let live_in = func
-                        .entry
+                        .entry()
                         .live_out()
                         .intersection_c(&RegSets::argument())
                         .union_c(&live_in_temp);

--- a/riscv_analysis/src/cfg/display.rs
+++ b/riscv_analysis/src/cfg/display.rs
@@ -5,6 +5,8 @@ use std::{
 
 use itertools::Itertools;
 
+use crate::parser::{Label, LabelString};
+
 use super::{CFGNode, Cfg};
 
 pub trait SetListString {
@@ -42,9 +44,13 @@ where
 
 impl Display for CFGNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let fn_label = match self.function().as_ref() {
-            Some(func) => func.name().0,
-            None => "N/A".to_string(),
+        let fn_label = match self.functions().len() {
+            0 => "N/A".to_string(),
+            _ => self.functions()
+                     .iter()
+                     .map(|f| f.name().0)
+                     .collect::<Vec<String>>()
+                     .join(" | "),
         };
 
         f.write_fmt(format_args!("{}\n", self.node()))?;

--- a/riscv_analysis/src/cfg/display.rs
+++ b/riscv_analysis/src/cfg/display.rs
@@ -5,8 +5,6 @@ use std::{
 
 use itertools::Itertools;
 
-use crate::parser::{Label, LabelString};
-
 use super::{CfgNode, Cfg};
 
 pub trait SetListString {
@@ -48,7 +46,7 @@ impl Display for CfgNode {
             0 => "N/A".to_string(),
             _ => self.functions()
                      .iter()
-                     .map(|f| f.name().0)
+                     .map(|func| func.name().0)
                      .join(" | "),
         };
 
@@ -62,7 +60,7 @@ impl Display for CfgNode {
         ))?;
         f.write_fmt(format_args!("  | UDEF | {}\n", self.u_def().str()))?;
         f.write_fmt(format_args!("  | NEXT | {}\n", self.nexts().len()))?;
-        f.write_fmt(format_args!("  | FN   | {}\n", fn_label))?;
+        f.write_fmt(format_args!("  | FN   | {fn_label}\n"))?;
 
         Ok(())
     }

--- a/riscv_analysis/src/cfg/display.rs
+++ b/riscv_analysis/src/cfg/display.rs
@@ -42,6 +42,11 @@ where
 
 impl Display for CFGNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fn_label = match self.function().as_ref() {
+            Some(func) => func.name().0,
+            None => "N/A".to_string(),
+        };
+
         f.write_fmt(format_args!("{}\n", self.node()))?;
         f.write_fmt(format_args!("  | LIVI | {}\n", self.live_in().str()))?;
         f.write_fmt(format_args!("  | LIVO | {}\n", self.live_out().str()))?;
@@ -52,6 +57,7 @@ impl Display for CFGNode {
         ))?;
         f.write_fmt(format_args!("  | UDEF | {}\n", self.u_def().str()))?;
         f.write_fmt(format_args!("  | NEXT | {}\n", self.nexts().len()))?;
+        f.write_fmt(format_args!("  | FN   | {}\n", fn_label))?;
 
         Ok(())
     }

--- a/riscv_analysis/src/cfg/display.rs
+++ b/riscv_analysis/src/cfg/display.rs
@@ -49,7 +49,6 @@ impl Display for CfgNode {
             _ => self.functions()
                      .iter()
                      .map(|f| f.name().0)
-                     .collect::<Vec<String>>()
                      .join(" | "),
         };
 

--- a/riscv_analysis/src/cfg/function.rs
+++ b/riscv_analysis/src/cfg/function.rs
@@ -1,4 +1,5 @@
 use std::{cell::{Ref, RefCell}, collections::HashSet, hash::Hash, rc::Rc};
+use uuid::Uuid;
 
 use crate::{
     analysis::CustomClonedSets,
@@ -9,6 +10,8 @@ use super::CfgNode;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Function {
+    uuid: Uuid,
+
     /// Labels for the entry point of this function
     labels: HashSet<With<LabelString>>,
 
@@ -28,7 +31,7 @@ pub struct Function {
 
 impl Hash for Function {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.name().hash(state);
+        self.uuid.hash(state);
     }
 }
 
@@ -52,6 +55,7 @@ impl Function {
         exit: Rc<CfgNode>,
     ) -> Self {
         Function {
+            uuid: Uuid::new_v4(),
             labels: labels.into_iter().collect::<HashSet<_>>(),
             nodes: RefCell::new(nodes),
             entry,

--- a/riscv_analysis/src/cfg/function.rs
+++ b/riscv_analysis/src/cfg/function.rs
@@ -79,8 +79,8 @@ impl Function {
         self.exit().live_in().intersection_c(&RegSets::ret())
     }
 
-    /// Insert the set of registers used by this function.
-    pub fn insert_defs(&self, defs: HashSet<Register>) {
+    /// Set the registers used by this function.
+    pub fn set_defs(&self, defs: HashSet<Register>) {
         *self.defs.borrow_mut() = defs;
     }
 
@@ -97,8 +97,8 @@ impl Function {
             .difference_c(&vec![Register::X2].into_iter().collect())
     }
 
-    /// Insert the instructions composing this function.
-    pub fn insert_nodes(&self, instructions: Vec<Rc<CfgNode>>) {
+    /// Set the instructions composing this function.
+    pub fn set_nodes(&self, instructions: Vec<Rc<CfgNode>>) {
         *self.nodes.borrow_mut() = instructions;
     }
 

--- a/riscv_analysis/src/cfg/function.rs
+++ b/riscv_analysis/src/cfg/function.rs
@@ -20,7 +20,7 @@ pub struct Function {
 
     /// Exit node of the function. Multiple exit points will be converted to a
     /// single exit point.
-    pub exit: Rc<CFGNode>,
+    exit: RefCell<Rc<CFGNode>>,
 
     /// The registers that are set ever in the function
     defs: RefCell<HashSet<Register>>,
@@ -55,7 +55,7 @@ impl Function {
             labels: labels.into_iter().collect::<HashSet<_>>(),
             nodes: RefCell::new(nodes),
             entry,
-            exit,
+            exit: RefCell::new(exit),
             defs: RefCell::new(HashSet::new()),
         }
     }
@@ -72,7 +72,7 @@ impl Function {
 
     #[must_use]
     pub fn returns(&self) -> HashSet<Register> {
-        self.exit.live_in().intersection_c(&RegSets::ret())
+        self.exit().live_in().intersection_c(&RegSets::ret())
     }
 
     /// Insert the set of registers used by this function.
@@ -101,5 +101,16 @@ impl Function {
     /// Return the instructions in the function.
     pub fn nodes(&self) -> Ref<Vec<Rc<CFGNode>>> {
         self.nodes.borrow()
+    }
+
+    /// Return the exit node of this function. In general, this corresponds to a
+    /// `ret` instruction.
+    pub fn exit(&self) -> Ref<Rc<CFGNode>> {
+        self.exit.borrow()
+    }
+
+    /// Set the exit node of this function.
+    pub fn set_exit(&self, node: Rc<CFGNode>) {
+        *self.exit.borrow_mut() = node;
     }
 }

--- a/riscv_analysis/src/cfg/function.rs
+++ b/riscv_analysis/src/cfg/function.rs
@@ -94,23 +94,23 @@ impl Function {
     }
 
     /// Insert the instructions composing this function.
-    pub fn insert_nodes(&self, instructions: Vec<Rc<CFGNode>>) {
+    pub fn insert_nodes(&self, instructions: Vec<Rc<CfgNode>>) {
         *self.nodes.borrow_mut() = instructions;
     }
 
     /// Return the instructions in the function.
-    pub fn nodes(&self) -> Ref<Vec<Rc<CFGNode>>> {
+    pub fn nodes(&self) -> Ref<Vec<Rc<CfgNode>>> {
         self.nodes.borrow()
     }
 
     /// Return the exit node of this function. In general, this corresponds to a
     /// `ret` instruction.
-    pub fn exit(&self) -> Ref<Rc<CFGNode>> {
+    pub fn exit(&self) -> Ref<Rc<CfgNode>> {
         self.exit.borrow()
     }
 
     /// Set the exit node of this function.
-    pub fn set_exit(&self, node: Rc<CFGNode>) {
+    pub fn set_exit(&self, node: Rc<CfgNode>) {
         *self.exit.borrow_mut() = node;
     }
 }

--- a/riscv_analysis/src/cfg/function.rs
+++ b/riscv_analysis/src/cfg/function.rs
@@ -109,7 +109,7 @@ impl Function {
 
     /// Return the entry node of this function.
     pub fn entry(&self) -> Rc<CfgNode> {
-        self.entry.clone()
+        Rc::clone(&self.entry)
     }
 
     /// Return the exit node of this function. In general, this corresponds to a

--- a/riscv_analysis/src/cfg/function.rs
+++ b/riscv_analysis/src/cfg/function.rs
@@ -19,7 +19,7 @@ pub struct Function {
     nodes: RefCell<Vec<Rc<CfgNode>>>,
 
     /// Entry node of the function.
-    pub entry: Rc<CfgNode>,
+    entry: Rc<CfgNode>,
 
     /// Exit node of the function. Multiple exit points will be converted to a
     /// single exit point.
@@ -105,6 +105,11 @@ impl Function {
     /// Return the instructions in the function.
     pub fn nodes(&self) -> Ref<Vec<Rc<CfgNode>>> {
         self.nodes.borrow()
+    }
+
+    /// Return the entry node of this function.
+    pub fn entry(&self) -> Rc<CfgNode> {
+        self.entry.clone()
     }
 
     /// Return the exit node of this function. In general, this corresponds to a

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -265,7 +265,7 @@ impl CfgNode {
     pub fn is_function_entry(&self) -> Option<Rc<Function>> {
         for func in self.functions().iter() {
             let func = func.clone();
-            if &*func.entry == self {
+            if &*func.entry() == self {
                 return Some(func)
             }
         }

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -264,13 +264,12 @@ impl CfgNode {
     /// If this node is an entry point, return the corresponding function.
     pub fn is_function_entry(&self) -> Option<Rc<Function>> {
         for func in self.functions().iter() {
-            let func = func.clone();
+            let func = Rc::clone(func);
             if &*func.entry() == self {
                 return Some(func)
             }
         }
-
-        return None;
+        None
     }
 
     /// Return true if this node is part of a function.

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -274,7 +274,7 @@ impl CfgNode {
     }
 
     /// Return true if this node is part of a function.
-    pub fn has_function(&self) -> bool {
+    pub fn is_part_of_some_function(&self) -> bool {
         return self.functions().len() > 0;
     }
 

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -26,11 +26,9 @@ pub struct CfgNode {
     nexts: RefCell<HashSet<Rc<CfgNode>>>,
     /// CFG nodes that come before this one (backward edges).
     prevs: RefCell<HashSet<Rc<CfgNode>>>,
-    /// If this CFG node is part of a function, which function
-    /// is it part of?
+    /// Which functions, if any, is this node a part of.
     ///
-    /// Every CFG node can only ever be part of one function.
-    /// We do not allow one node to be part of more than one.
+    /// Note that a node could be a part of 0, 1 or more functions.
     function: RefCell<HashSet<Rc<Function>>>,
     /// Map each register to the available value that is set before
     /// the instruction represented by this CFG node is run.

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -92,7 +92,7 @@ impl NodeWrapper {
             func_exit: node.functions().iter().map(|func| {
                 cfg.nodes
                     .iter()
-                    .position(|other| func.exit.node().id() == other.node().id())
+                    .position(|other| func.exit().node().id() == other.node().id())
                     .unwrap()
             }).collect::<Vec<_>>(),
             nexts: node

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -94,7 +94,7 @@ impl NodeWrapper {
             func_entry: node.functions().iter().map(|func| {
                 cfg.nodes
                     .iter()
-                    .position(|other| func.entry.node().id() == other.node().id())
+                    .position(|other| func.entry().node().id() == other.node().id())
                     .unwrap()
             }).collect::<Vec<_>>(),
             func_exit: node.functions().iter().map(|func| {

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -20,10 +20,8 @@ pub struct NodeWrapper {
         serialize_with = "sorted_set"
     )]
     pub labels: HashSet<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub func_entry: Option<usize>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub func_exit: Option<usize>,
+    pub func_entry: Vec<usize>,
+    pub func_exit: Vec<usize>,
     #[serde(
         default,
         skip_serializing_if = "HashSet::is_empty",
@@ -85,18 +83,18 @@ impl NodeWrapper {
         NodeWrapper {
             node: node.node(),
             labels: node.labels.iter().map(|x| x.data.0.clone()).collect(),
-            func_entry: node.function().clone().map(|x| {
+            func_entry: node.functions().iter().map(|func| {
                 cfg.nodes
                     .iter()
-                    .position(|y| x.entry.node().id() == y.node().id())
+                    .position(|other| func.entry.node().id() == other.node().id())
                     .unwrap()
-            }),
-            func_exit: node.function().clone().map(|x| {
+            }).collect::<Vec<_>>(),
+            func_exit: node.functions().iter().map(|func| {
                 cfg.nodes
                     .iter()
-                    .position(|y| x.exit.node().id() == y.node().id())
+                    .position(|other| func.exit.node().id() == other.node().id())
                     .unwrap()
-            }),
+            }).collect::<Vec<_>>(),
             nexts: node
                 .nexts()
                 .iter()

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -20,7 +20,15 @@ pub struct NodeWrapper {
         serialize_with = "sorted_set"
     )]
     pub labels: HashSet<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+    )]
     pub func_entry: Vec<usize>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+    )]
     pub func_exit: Vec<usize>,
     #[serde(
         default,

--- a/riscv_analysis/src/fix/mod.rs
+++ b/riscv_analysis/src/fix/mod.rs
@@ -68,7 +68,7 @@ pub fn get_function_label_ranges(cfg: &Cfg) -> Vec<Range> {
 pub fn fix_stack(func: &Rc<Function>) -> Vec<Manipulation> {
     // go to the beginning of the function
     let entry = &func.entry;
-    let exit = &func.exit;
+    let exit = &func.exit();
     // sorted to make the output nicer
     let regs = func.to_save().into_iter().sorted().collect_vec();
     let count = regs.len();

--- a/riscv_analysis/src/fix/mod.rs
+++ b/riscv_analysis/src/fix/mod.rs
@@ -68,7 +68,7 @@ pub fn get_function_label_ranges(cfg: &Cfg) -> Vec<Range> {
 #[must_use]
 pub fn fix_stack(func: &Rc<Function>) -> Vec<Manipulation> {
     // go to the beginning of the function
-    let entry = &func.entry;
+    let entry = &func.entry();
     let exit = &func.exit();
     // sorted to make the output nicer
     let regs = func.to_save().into_iter().sorted().collect_vec();

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -19,10 +19,11 @@ struct MarkData {
 pub struct FunctionMarkupPass;
 
 impl FunctionMarkupPass {
-    fn mark_reachable(entry: Rc<CfgNode>, func: Rc<Function>)
+    fn mark_reachable(entry: &Rc<CfgNode>, func: &Rc<Function>)
                       -> Result<MarkData, Box<CfgError>> {
         // Initialize data for graph search
-        let mut queue = vec![entry.clone()];
+        let mut queue = vec![Rc::clone(entry)];
+        #[allow(clippy::mutable_key_type)]  // This is okay because we don't modify the field that is hashed
         let mut seen = HashSet::new();      // CFG nodes seen during the traversal
         let mut defs = HashSet::new();      // Registers this function writes to
         let mut returns = None;             // Return instructions in this function
@@ -32,12 +33,11 @@ impl FunctionMarkupPass {
             // Only process each node at most once
             if seen.contains(&node) {
                 continue;
-            } else {
-                seen.insert(node.clone());
             }
+            seen.insert(Rc::clone(&node));
 
             // Mark the node as being a part of the given function
-            node.insert_function(func.clone());
+            node.insert_function(Rc::clone(func));
 
             // Collect any registers written to by the node
             if let Some(dest) = node.node().stores_to() {
@@ -77,24 +77,26 @@ impl FunctionMarkupPass {
 
                 // If this is the first return node, save it
                 else {
-                    returns = Some(node.clone());
+                    returns = Some(Rc::clone(&node));
                 }
             }
 
             // Add all successor nodes to the queue
             let successors = node.nexts();
             for suc in successors.iter() {
-                queue.push(suc.clone());
+                queue.push(Rc::clone(suc));
             }
         }
 
         let instructions = seen.into_iter().collect();
 
-        // TODO: Handle functions with no return statements
         if let Some(ret) = returns {
-            return Ok(MarkData { found: defs, instructions, returns: ret });
-        } else {
-            unimplemented!();
+            Ok(MarkData { found: defs, instructions, returns: ret })
+        }
+
+        // TODO: Handle functions with no return statements
+        else {
+            Err(Box::new(CfgError::UnexpectedError))
         }
     }
 }
@@ -119,22 +121,22 @@ impl GenerationPass for FunctionMarkupPass {
             // Get the labels for the entry block
             let labels = entry.labels()
                               .iter()
-                              .map(|l| l.clone())
+                              .cloned()
                               .collect::<Vec<_>>();
 
             // Insert a new function into the CFG
             let func = Rc::new(Function::new(
-                labels.clone(), vec![], entry.clone(), entry.clone()
+                labels.clone(), vec![], Rc::clone(&entry), Rc::clone(&entry)
             ));
 
-            for label in labels.iter() {
-                label_function_map.insert(label.clone(), func.clone());
+            for label in &labels {
+                label_function_map.insert(label.clone(), Rc::clone(&func));
             }
 
 
             // Mark all CFG nodes that are reachable from this entry point
             // FIXME: What to do if there is more than one return
-            match Self::mark_reachable(entry, func.clone()) {
+            match Self::mark_reachable(&entry, &Rc::clone(&func)) {
                 Ok(data) => {
                     func.set_defs(data.found);
                     func.set_nodes(data.instructions);

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -5,13 +5,59 @@ use std::{
 };
 
 use crate::{
-    cfg::{Cfg, Function},
+    cfg::{CFGNode, Cfg, Function},
     parser::Register,
-    parser::{Info, JumpLinkType, LabelString, ParserNode, With},
-    passes::{CFGError, DiagnosticLocation, GenerationPass},
+    passes::{CFGError, GenerationPass},
 };
 
 pub struct FunctionMarkupPass;
+
+impl FunctionMarkupPass {
+    fn mark_reachable(entry: Rc<CFGNode>, func: Rc<Function>)
+                      -> Result<HashSet<Register>, Box<CFGError>> {
+        // Initialize data for graph search
+        let mut queue = vec![entry.clone()];
+        let mut seen = HashSet::new();
+
+        // Which registers does this function write to?
+        let mut found = HashSet::new();
+
+        // Traverse the CFG for all nodes reachable from the entry point
+        while let Some(node) = queue.pop() {
+            // Only process each node at most once
+            if seen.contains(&node) {
+                continue;
+            } else {
+                seen.insert(node.clone());
+            }
+
+            // If this node is already marked, then two (or more) functions
+            // share some code
+            if node.function().is_some() {
+                return Err(Box::new(
+                    CFGError::MultipleFunctions(node.node(), entry.labels())
+                ))
+            }
+
+            // Mark this node as being a part of this function
+            node.set_function(func.clone());
+
+            // Collect any registers written to by this instruction
+            if let Some(dest) = node.node().stores_to() {
+                found.insert(dest.data);
+            }
+
+            // Add all successor nodes to the queue
+            let successors = node.nexts();
+            for suc in successors.iter() {
+                queue.push(suc.clone());
+            }
+        }
+
+        return Ok(found);
+    }
+}
+
 impl GenerationPass for FunctionMarkupPass {
     fn run(cfg: &mut Cfg) -> Result<(), Box<CFGError>> {
         let mut label_function_map: HashMap<
@@ -23,124 +69,34 @@ impl GenerationPass for FunctionMarkupPass {
         // --------------------
         // Graph traversal to find functions
 
-        for node in &*cfg {
-            if node.node().is_return() {
-                // Walk backwards from return label to find function starts
-                let mut walked = Vec::new();
-                let mut queue = vec![Rc::clone(&node)];
-                let mut found = Vec::new();
-                let mut defs = HashSet::new();
+        for entry in &*cfg {
+            // Skip all nodes that are not entry points
+            if !entry.node().is_function_entry() {
+                continue;
+            }
 
-                // For all items in the queue
-                'inner: while let Some(n) = queue.pop() {
-                    walked.push(Rc::clone(&n));
-                    if let Some(def) = n.node().stores_to() {
-                        defs.insert(def.data);
-                    }
+            // Insert a new function into the CFG
+            let func = Rc::new(Function::new(
+                // FIXME: Dummy values
+                vec![], entry.clone(), entry.clone()
+            ));
 
-                    // If we reach the program entry, there's an issue
-                    if n.node().is_program_entry() {
-                        return Err(Box::new(CFGError::NoLabelForReturn(node.node())));
-                    }
+            let labels = entry.labels()
+                              .iter()
+                              .map(|l| l.clone())
+                              .collect::<Vec<_>>();
+            for label in labels.iter() {
+                label_function_map.insert(label.clone(), func.clone());
+            }
 
-                    // If we find a function entry, we're done
-                    if n.node().is_function_entry() {
-                        found.push(Rc::clone(&n));
-                        continue 'inner;
-                    }
-
-                    // Otherwise, add all previous nodes to the queue
-                    for prev in &*n.prevs() {
-                        if !walked.contains(prev) {
-                            queue.push(Rc::clone(prev));
-                        }
-                    }
-                }
-
-                // If we found multiple function entries, we have a problem
-                if found.len() > 1 {
-                    return Err(Box::new(CFGError::MultipleLabelsForReturn(
-                        node.node(),
-                        found.iter().flat_map(|x| x.labels.clone()).collect(),
-                    )));
-                }
-
-                // Otherwise, we found a function and all its nodes
-                if let Some(entry_node) = found.first() {
-                    // Add the function to the map
-                    let func = Rc::new(Function::new(
-                        walked,
-                        Rc::clone(entry_node),
-                        Rc::clone(&node),
-                        defs,
-                    ));
-
-                    // The label function map can have multiple entries corresponding to the single
-                    // function, because that function has multiple labels. That makes this a bit
-                    // messy because we want to ensure that every case is covered.
-                    let mut exists = None;
-                    'inn: for label in entry_node.labels() {
-                        if let Some(existing_func) = label_function_map.get(&label) {
-                            // Since we already have a "return" for this function,
-                            // we will convert the new return to an unconditional jump
-                            // to the existing return
-                            exists = Some(existing_func);
-                            break 'inn;
-                        }
-                    }
-
-                    if let Some(existing_func) = exists {
-                        // Convert the return node to an unconditional jump
-
-                        // Get the return node, which will become an unconditional jump
-                        let return_node = Rc::clone(&node);
-
-                        // Get the existing return node -- will stay the same
-                        let existing_return_node = Rc::clone(&existing_func.exit);
-
-                        // Clear nexts of return node, and add existing return
-                        // TODO convert next/prev setting to function to enforce
-                        // At this point, the nexts of the return nodes should be all empty
-                        // TODO assert that the nexts for both don't exist
-                        return_node.clear_nexts();
-                        return_node.insert_next(Rc::clone(&existing_return_node));
-
-                        // Set return node's prev to original return node
-                        existing_return_node.insert_prev(Rc::clone(&return_node));
-
-                        // Convert node to jump
-                        let inf = Info {
-                            token: crate::parser::Token::Symbol("return".to_string()),
-                            pos: return_node.node().range().clone(),
-                            file: return_node.node().file(),
-                        };
-
-                        let inst = With::new(JumpLinkType::Jal, inf.clone());
-                        let rd = With::new(Register::X0, inf.clone());
-                        let name = With::new(LabelString("__return__".to_string()), inf.clone());
-                        let new_node = ParserNode::new_jump_link(
-                            inst,
-                            rd,
-                            name,
-                            existing_return_node.node().token(),
-                        );
-                        return_node.set_node(new_node);
-                    } else {
-                        for label in entry_node.labels() {
-                            label_function_map.insert(label.clone(), Rc::clone(&func));
-                        }
-                    }
-
-                    // Add the function to the nodes
-                    for func_node in &func.nodes {
-                        func_node.set_function(Rc::clone(&func));
-                    }
-                } else {
-                    // If we found no function entries, we have a problem
-                    return Err(Box::new(CFGError::NoLabelForReturn(node.node())));
-                }
+            // Mark all CFG nodes that are reachable from this entry point
+            // FIXME: What to do if there is more than one return
+            match Self::mark_reachable(entry, func.clone()) {
+                Ok(defs) => { func.insert_defs(defs); },
+                Err(e) => { return Err(e); }
             }
         }
+
         cfg.label_function_map = label_function_map;
         Ok(())
     }

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -12,15 +12,15 @@ use crate::{
 
 struct MarkData {
     pub found: HashSet<Register>,
-    pub instructions: Vec<Rc<CFGNode>>,
-    pub returns: Rc<CFGNode>,
+    pub instructions: Vec<Rc<CfgNode>>,
+    pub returns: Rc<CfgNode>,
 }
 
 pub struct FunctionMarkupPass;
 
 impl FunctionMarkupPass {
-    fn mark_reachable(entry: Rc<CFGNode>, func: Rc<Function>)
-                      -> Result<MarkData, Box<CFGError>> {
+    fn mark_reachable(entry: Rc<CfgNode>, func: Rc<Function>)
+                      -> Result<MarkData, Box<CfgError>> {
         // Initialize data for graph search
         let mut queue = vec![entry.clone()];
         let mut seen = HashSet::new();      // CFG nodes seen during the traversal

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -37,17 +37,11 @@ impl FunctionMarkupPass {
 
             // If this node is already marked, then two (or more) functions
             // share some code
-            if node.function().is_some() {
+            if let Some(func) = node.function().as_deref() {
+                let labels: HashSet<_>
+                    = node.labels().union(&func.labels()).map(|e| e.clone()).collect();
                 return Err(Box::new(
-                    CFGError::MultipleFunctions(node.node(), entry.labels())
-                ));
-            }
-
-            // If this node has a different function label, something is wrong
-            if node.is_function_entry().is_some()
-                && !node.labels().is_subset(&func.labels()) {
-                return Err(Box::new(
-                    CFGError::MultipleFunctions(node.node(), node.labels())
+                    CFGError::MultipleFunctions(node.node(), labels)
                 ));
             }
 
@@ -71,7 +65,7 @@ impl FunctionMarkupPass {
             }
         }
 
-        // Error out if the function has more than one return
+        // If there is more than one return, signal an error
         // TODO: Handle functions with more than one return statement
         if returns.len() != 1 {
             unimplemented!();

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -106,6 +106,7 @@ impl GenerationPass for FunctionMarkupPass {
                 Ok(data) => {
                     func.insert_defs(data.found);
                     func.insert_nodes(data.instructions);
+                    func.set_exit(data.returns);
                 },
                 Err(e) => { return Err(e); }
             }

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -136,8 +136,8 @@ impl GenerationPass for FunctionMarkupPass {
             // FIXME: What to do if there is more than one return
             match Self::mark_reachable(entry, func.clone()) {
                 Ok(data) => {
-                    func.insert_defs(data.found);
-                    func.insert_nodes(data.instructions);
+                    func.set_defs(data.found);
+                    func.set_nodes(data.instructions);
                     func.set_exit(data.returns);
                 },
                 Err(e) => { return Err(e); }

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -169,20 +169,23 @@ impl LintPass for ControlFlowCheck {
                     // Note: this also accounts for functions being at the beginning
                     // of a program, as the ProgEntry node will be the previous node
                     if let Some(prev_node) = node.prevs().iter().next() {
-                        if let Some(function) = node.function().clone() {
+                        for function in node.functions().iter() {
                             if prev_node.node().is_program_entry() {
                                 errors.push(LintError::FirstInstructionIsFunction(
                                     node.node().clone(),
-                                    function,
+                                    function.clone(),
                                 ));
                             } else {
                                 errors.push(LintError::InvalidJumpToFunction(
                                     node.node().clone(),
                                     prev_node.node().clone(),
-                                    function,
+                                    function.clone(),
                                 ));
                             }
+
                         }
+                        // if let Some(function) = node.functions().clone() {
+                        // }
                     }
                 }
                 ParserNode::ProgramEntry(_) => {}
@@ -368,8 +371,7 @@ impl LintPass for LostCalleeSavedRegisterCheck {
             // as the value is mean to be modified
             if let Some(reg) = node.node().stores_to() {
                 if callee.contains(&reg.data) {
-                    let func = node.function().clone();
-                    if func.is_some()
+                    if node.has_function()
                         && node.reg_values_in().get(&reg.data)
                             == Some(&AvailableValue::OriginalRegisterWithScalar(reg.data, 0))
                     {

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -369,7 +369,7 @@ impl LintPass for LostCalleeSavedRegisterCheck {
             // as the value is mean to be modified
             if let Some(reg) = node.node().stores_to() {
                 if callee.contains(&reg.data) {
-                    if node.has_function()
+                    if node.is_part_of_some_function()
                         && node.reg_values_in().get(&reg.data)
                             == Some(&AvailableValue::OriginalRegisterWithScalar(reg.data, 0))
                     {

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -379,7 +379,7 @@ impl LintPass for LostCalleeSavedRegisterCheck {
                     let mut found = false;
 
                     // check stack values:
-                    let stack = node.stack_values_out();
+                    let stack = node.memory_values_out();
                     for (_, val) in stack {
                         if let AvailableValue::OriginalRegisterWithScalar(reg2, offset) = val {
                             if reg2 == reg.data && offset == 0 {

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -184,8 +184,6 @@ impl LintPass for ControlFlowCheck {
                             }
 
                         }
-                        // if let Some(function) = node.functions().clone() {
-                        // }
                     }
                 }
                 ParserNode::ProgramEntry(_) => {}

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -331,7 +331,7 @@ pub struct CalleeSavedRegisterCheck;
 impl LintPass for CalleeSavedRegisterCheck {
     fn run(cfg: &Cfg, errors: &mut Vec<LintError>) {
         for func in cfg.label_function_map.values() {
-            let exit_vals = func.exit.reg_values_in();
+            let exit_vals = func.exit().reg_values_in();
             for reg in RegSets::callee_saved() {
                 match exit_vals.get(&reg) {
                     Some(AvailableValue::OriginalRegisterWithScalar(reg2, offset))
@@ -345,7 +345,7 @@ impl LintPass for CalleeSavedRegisterCheck {
                         // This means that we are overwriting a callee-saved register
                         // We will traverse the function to find the first time
                         // from the return point that that register was overwritten.
-                        let ranges = Cfg::error_ranges_for_first_store(&func.exit, reg);
+                        let ranges = Cfg::error_ranges_for_first_store(&func.exit(), reg);
                         for range in ranges {
                             errors.push(LintError::OverwriteCalleeSavedRegister(range));
                         }

--- a/riscv_analysis/src/passes/cfg_error.rs
+++ b/riscv_analysis/src/passes/cfg_error.rs
@@ -66,7 +66,7 @@ impl Display for CfgError {
             CfgError::NoLabelForReturn(_) => {
                 write!(f, "No label for return")
             }
-            CfGError::UnexpectedError => write!(f, "Unexpected error"),
+            CfgError::UnexpectedError => write!(f, "Unexpected error"),
             CfgError::AssertionError => write!(f, "Assertion error"),
             CfgError::OverlappingFunctions(_, labels) => {
                 write!(f, "Instruction in multiple functions: {}", labels.as_str_list())

--- a/riscv_analysis_cli/resources/test/loop_check/raw.yaml
+++ b/riscv_analysis_cli/resources/test/loop_check/raw.yaml
@@ -222,8 +222,10 @@
 - node: !FuncEntry {}
   labels:
   - func1
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 10
   reg_values_out:
@@ -305,8 +307,10 @@
     rd: 2
     rs1: 2
     imm: -4
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 11
   prevs:
@@ -436,8 +440,10 @@
     rs1: 2
     rs2: 8
     imm: 0
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 12
   prevs:
@@ -570,8 +576,10 @@
     rd: 8
     rs1: 0
     imm: 32
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 13
   prevs:
@@ -709,8 +717,10 @@
     name: L2
   labels:
   - L1
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 14
   - 24
@@ -839,8 +849,10 @@
     rd: 2
     rs1: 2
     imm: -4
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 15
   prevs:
@@ -965,8 +977,10 @@
     rs1: 2
     rs2: 9
     imm: 0
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 16
   prevs:
@@ -1093,8 +1107,10 @@
     rd: 9
     rs1: 0
     imm: 64
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 17
   prevs:
@@ -1223,8 +1239,10 @@
     rd: 18
     rs1: 0
     imm: 39
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 18
   prevs:
@@ -1355,8 +1373,10 @@
     rd: 9
     rs1: 9
     rs2: 8
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 19
   prevs:
@@ -1488,8 +1508,10 @@
     rd: 9
     rs1: 9
     rs2: 10
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 20
   prevs:
@@ -1619,8 +1641,10 @@
     rd: 9
     rs1: 2
     imm: 0
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 21
   prevs:
@@ -1753,8 +1777,10 @@
     rd: 2
     rs1: 2
     imm: 4
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 22
   prevs:
@@ -1891,8 +1917,10 @@
     rd: 8
     rs1: 8
     imm: -1
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 23
   prevs:
@@ -2028,8 +2056,10 @@
     inst: Jal
     rd: 0
     name: L1
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 13
   prevs:
@@ -2168,8 +2198,10 @@
     rs2: 0
   labels:
   - L2
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 25
   prevs:
@@ -2295,8 +2327,10 @@
     rd: 8
     rs1: 2
     imm: 0
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 26
   prevs:
@@ -2426,8 +2460,10 @@
     rd: 2
     rs1: 2
     imm: 4
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   nexts:
   - 27
   prevs:
@@ -2561,8 +2597,10 @@
     rd: 0
     rs1: 1
     imm: 0
-  func_entry: 9
-  func_exit: 27
+  func_entry:
+  - 9
+  func_exit:
+  - 27
   prevs:
   - 26
   reg_values_in:

--- a/riscv_analysis_cli/resources/test/treg/raw.yaml
+++ b/riscv_analysis_cli/resources/test/treg/raw.yaml
@@ -291,8 +291,10 @@
 - node: !FuncEntry {}
   labels:
   - bar
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 12
   reg_values_out:
@@ -375,8 +377,10 @@
     rd: 2
     rs1: 2
     imm: -4
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 13
   prevs:
@@ -508,8 +512,10 @@
     rs1: 2
     rs2: 1
     imm: 0
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 14
   prevs:
@@ -644,8 +650,10 @@
     rs1: 2
     rs2: 8
     imm: 4
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 15
   prevs:
@@ -785,8 +793,10 @@
     rd: 8
     rs1: 0
     imm: 2
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 16
   prevs:
@@ -926,8 +936,10 @@
     inst: Jal
     rd: 1
     name: foo
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 17
   prevs:
@@ -1062,8 +1074,10 @@
     rd: 1
     rs1: 2
     imm: 0
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 18
   prevs:
@@ -1198,8 +1212,10 @@
     rd: 8
     rs1: 2
     imm: 4
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 19
   prevs:
@@ -1341,8 +1357,10 @@
     rd: 2
     rs1: 2
     imm: 4
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   nexts:
   - 20
   prevs:
@@ -1487,8 +1505,10 @@
     rd: 0
     rs1: 1
     imm: 0
-  func_entry: 11
-  func_exit: 20
+  func_entry:
+  - 11
+  func_exit:
+  - 20
   prevs:
   - 19
   reg_values_in:
@@ -1614,8 +1634,10 @@
 - node: !FuncEntry {}
   labels:
   - foo
-  func_entry: 21
-  func_exit: 23
+  func_entry:
+  - 21
+  func_exit:
+  - 23
   nexts:
   - 22
   reg_values_out:
@@ -1698,8 +1720,10 @@
     rd: 10
     rs1: 10
     rs2: 11
-  func_entry: 21
-  func_exit: 23
+  func_entry:
+  - 21
+  func_exit:
+  - 23
   nexts:
   - 23
   prevs:
@@ -1829,8 +1853,10 @@
     rd: 0
     rs1: 1
     imm: 0
-  func_entry: 21
-  func_exit: 23
+  func_entry:
+  - 21
+  func_exit:
+  - 23
   prevs:
   - 22
   reg_values_in:


### PR DESCRIPTION
**Summary**: 
Change the function annotation pass to be top-down instead of bottom-up. Also allow an instruction to be part of more than one function.

**Test plan**:
The builtin CLI tests were modified slightly to allow for more than one function. When the parser is updated to allow string inputs, further tests will be added to the function annotation pass. 
