### PR TITLE
[RV-20] feat: add entry-point function for parsing a string into a list of `ParserNode`s

### DIFF
--- a/riscv_analysis/src/parser/empty_file_reader.rs
+++ b/riscv_analysis/src/parser/empty_file_reader.rs
@@ -1,0 +1,149 @@
+use uuid::Uuid;
+
+use crate::reader::{FileReader, FileReaderError};
+
+/// A file reader that cannot read from any paths.
+///
+/// This file reader is useful when we want to create a
+/// parser that needs a file reader, but we know that the
+/// parser will not need to read from any files or cannot
+/// read from any files. This is useful for testing.
+///
+/// Using this file reader will prevent the usage of
+/// any `.include` directives in the parser. Every
+/// use of `.include` will result in an error.
+#[derive(Debug, Clone)]
+pub struct EmptyFileReader {
+    base_file_contents: String,
+    base_file_uuid: Option<Uuid>,
+}
+
+impl EmptyFileReader {
+    /// Create a new empty file reader.
+    ///
+    /// An `EmptyFileReader` is a file reader that cannot read from any paths.
+    /// It takes in the file text that the base file should contain.
+    #[must_use]
+    pub fn new(text: &str) -> Self {
+        Self {
+            base_file_contents: text.to_string(),
+            base_file_uuid: None,
+        }
+    }
+
+    /// Get the "fake" file path used for the base file.
+    ///
+    /// The interface for a file reader requires a notion of a file path or file reader.
+    /// This function returns the file path that the base file is expected to have.
+    ///
+    /// ```
+    /// use riscv_analysis::parser::EmptyFileReader;
+    /// assert_eq!(EmptyFileReader::get_file_path(), "base_file.s");
+    /// ```
+    #[must_use]
+    pub fn get_file_path() -> &'static str {
+        "base_file.s"
+    }
+}
+
+impl FileReader for EmptyFileReader {
+    fn import_file(
+        &mut self,
+        path: &str,
+        parent_file: Option<uuid::Uuid>,
+    ) -> Result<(Uuid, String), FileReaderError> {
+        if parent_file.is_some() {
+            Err(FileReaderError::Unexpected)
+        } else if self.base_file_uuid.is_some() {
+            Err(FileReaderError::FileAlreadyRead(
+                Self::get_file_path().to_string(),
+            ))
+        } else if path != Self::get_file_path() {
+            Err(FileReaderError::InternalFileNotFound)
+        } else {
+            let uuid = uuid::Uuid::new_v4();
+            self.base_file_uuid = Some(uuid);
+            Ok((uuid, self.base_file_contents.clone()))
+        }
+    }
+
+    fn get_text(&self, uuid: uuid::Uuid) -> Option<String> {
+        if uuid == self.base_file_uuid? {
+            Some(self.base_file_contents.clone())
+        } else {
+            None
+        }
+    }
+
+    fn get_filename(&self, uuid: uuid::Uuid) -> Option<String> {
+        if uuid == self.base_file_uuid? {
+            Some(Self::get_file_path().to_string())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn can_read_from_text() {
+        let text = "Hello, world!";
+        let mut reader = EmptyFileReader::new(text);
+
+        let (uuid, contents) = reader
+            .import_file(&EmptyFileReader::get_file_path(), None)
+            .expect("File reading should not fail");
+        assert_eq!(contents, text);
+
+        let text = reader
+            .get_text(uuid)
+            .expect("File path should exist in reader");
+        assert_eq!(text, "Hello, world!");
+
+        let filename = reader
+            .get_filename(uuid)
+            .expect("File name should exist for base reader");
+        assert_eq!(filename, EmptyFileReader::get_file_path());
+    }
+
+    #[test]
+    fn can_get_error_for_invalid_paths() {
+        let text = "Hello, world!";
+        let mut reader = EmptyFileReader::new(text);
+
+        let result = reader.import_file("invalid_path.s", None);
+        assert!(matches!(result, Err(FileReaderError::InternalFileNotFound)));
+    }
+
+    #[test]
+    fn can_get_error_for_including_a_parent_uuid() {
+        let text = "Hello, world!";
+        let mut reader = EmptyFileReader::new(text);
+
+        let result = reader.import_file(EmptyFileReader::get_file_path(), Some(Uuid::new_v4()));
+        assert!(matches!(result, Err(FileReaderError::Unexpected)));
+
+        let result = reader.import_file(EmptyFileReader::get_file_path(), Some(Uuid::nil()));
+        assert!(matches!(result, Err(FileReaderError::Unexpected)));
+    }
+
+    #[test]
+    fn can_read_empty_text() {
+        let text = "";
+        let mut reader = EmptyFileReader::new(text);
+
+        let (uuid, contents) = reader
+            .import_file(&EmptyFileReader::get_file_path(), None)
+            .expect("File reading should not fail");
+        assert_eq!(contents, text);
+
+        let text = reader
+            .get_text(uuid)
+            .expect("File path should exist in reader");
+        assert_eq!(text, "");
+    }
+}

--- a/riscv_analysis/src/parser/mod.rs
+++ b/riscv_analysis/src/parser/mod.rs
@@ -41,3 +41,6 @@ pub use directive::*;
 
 mod empty_file_reader;
 pub use empty_file_reader::*;
+
+mod rv_string_parser;
+pub use rv_string_parser::*;

--- a/riscv_analysis/src/parser/mod.rs
+++ b/riscv_analysis/src/parser/mod.rs
@@ -38,3 +38,6 @@ pub use details::*;
 
 mod directive;
 pub use directive::*;
+
+mod empty_file_reader;
+pub use empty_file_reader::*;

--- a/riscv_analysis/src/parser/parsing.rs
+++ b/riscv_analysis/src/parser/parsing.rs
@@ -38,7 +38,7 @@ where
 impl<T: FileReader + Clone> RVParser<T> {
     pub fn run(&mut self, base: &str) -> Vec<DiagnosticItem> {
         let mut diags = Vec::new();
-        let parsed = self.parse(base, false);
+        let parsed = self.parse_from_file(base, false);
         parsed
             .1
             .iter()
@@ -82,7 +82,7 @@ impl<T: FileReader + Clone> RVParser<T> {
     /// Parse files
     ///
     /// This function is responsible for parsing the file. It will continue until no imports are left.
-    pub fn parse(
+    pub fn parse_from_file(
         &mut self,
         base: &str,
         ignore_imports: bool,

--- a/riscv_analysis/src/parser/register.rs
+++ b/riscv_analysis/src/parser/register.rs
@@ -3,7 +3,6 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::parser::token::{Info, Token};
 use std::{
     collections::HashSet,
-    convert::TryFrom,
     fmt::Display,
     hash::{Hash, Hasher},
     str::FromStr,

--- a/riscv_analysis/src/parser/rv_string_parser.rs
+++ b/riscv_analysis/src/parser/rv_string_parser.rs
@@ -1,0 +1,75 @@
+use super::{EmptyFileReader, ParseError, ParserNode, RVParser};
+
+/// A simplified parser to read a string into `ParserNodes`, for testing.
+pub struct RVStringParser;
+
+impl RVStringParser {
+    /// Parse a string representation into a list of `ParserNodes` and `ParseErrors`,
+    /// for test purposes.
+    ///
+    /// This is a top-level function that is used to parse RISC-V assmebly text
+    /// into parser nodes. It is a wrapper for `RVParser` and should only be
+    /// used for test purposes, as it does not handle file reading.
+    ///
+    /// ```
+    /// use riscv_analysis::parser::{RVStringParser, ParserNode};
+    /// let (nodes, errors) = RVStringParser::parse_from_text("add x1, x10, x11\n");
+    /// assert_eq!(nodes.len(), 2);
+    /// assert_eq!(errors.len(), 0);
+    /// matches!(&nodes[0], ParserNode::ProgramEntry(_));
+    /// matches!(&nodes[1], ParserNode::Arith(_));
+    /// assert_eq!(nodes[1].to_string(), "add ra <- a0, a1");
+    /// ```
+    #[must_use]
+    pub fn parse_from_text(text: &str) -> (Vec<ParserNode>, Vec<ParseError>) {
+        let mut parser = RVParser::new(EmptyFileReader::new(text));
+        parser.parse_from_file(EmptyFileReader::get_file_path(), false)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn can_parse_from_text() {
+        let (nodes, errors) = RVStringParser::parse_from_text("add x1, x10, x11\n");
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(errors.len(), 0);
+        matches!(&nodes[0], ParserNode::ProgramEntry(_));
+        matches!(&nodes[1], ParserNode::Arith(_));
+        assert_eq!(nodes[1].to_string(), "add ra <- a0, a1");
+    }
+
+    #[test]
+    fn can_emit_parse_errors() {
+        let (nodes, errors) =
+            RVStringParser::parse_from_text("add x1, x10, x11\nadd x1, x10, x11\njall");
+        assert_eq!(nodes.len(), 3);
+        assert_eq!(errors.len(), 1);
+        matches!(&nodes[0], ParserNode::ProgramEntry(_));
+        matches!(&nodes[1], ParserNode::Arith(_));
+        matches!(&nodes[2], ParserNode::Arith(_));
+        matches!(&errors[0], ParseError::UnexpectedToken(_));
+    }
+
+    #[test]
+    fn can_emit_error_on_include_directive() {
+        let (nodes, errors) = RVStringParser::parse_from_text(".include \"file.s\"");
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(errors.len(), 1);
+        matches!(&nodes[0], ParserNode::Directive(_));
+        matches!(&errors[0], ParseError::FileNotFound(_));
+    }
+
+    #[test]
+    fn can_emit_error_on_self_reference() {
+        let text = format!(".include \"{}\"\n", EmptyFileReader::get_file_path());
+        let (nodes, errors) = RVStringParser::parse_from_text(&text);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(errors.len(), 1);
+        matches!(&nodes[0], ParserNode::Directive(_));
+        matches!(&errors[0], ParseError::FileNotFound(_));
+    }
+}

--- a/riscv_analysis/src/reader/mod.rs
+++ b/riscv_analysis/src/reader/mod.rs
@@ -21,7 +21,7 @@ pub trait FileReader: Sized {
     fn import_file(
         &mut self,
         path: &str,
-        in_file: Option<uuid::Uuid>,
+        parent_file: Option<uuid::Uuid>,
     ) -> Result<(Uuid, Peekable<Lexer>), FileReaderError>;
 
     fn get_text(&self, uuid: uuid::Uuid) -> Option<String>;

--- a/riscv_analysis/src/reader/mod.rs
+++ b/riscv_analysis/src/reader/mod.rs
@@ -1,8 +1,4 @@
-use std::iter::Peekable;
-
 use uuid::Uuid;
-
-use crate::parser::Lexer;
 
 #[derive(Debug)]
 pub enum FileReaderError {
@@ -14,15 +10,14 @@ pub enum FileReaderError {
 }
 
 pub trait FileReader: Sized {
-    /// Import and read a file into the reader
+    /// Import and read a file into the reader.
     ///
-    /// Returns the UUID of the file and a peekable lexer. This lexer will allow
-    /// you to search the file. Each file has its own attached lexer.
+    /// Returns the UUID of the file and a string containing the file's contents.
     fn import_file(
         &mut self,
         path: &str,
         parent_file: Option<uuid::Uuid>,
-    ) -> Result<(Uuid, Peekable<Lexer>), FileReaderError>;
+    ) -> Result<(Uuid, String), FileReaderError>;
 
     fn get_text(&self, uuid: uuid::Uuid) -> Option<String>;
 

--- a/riscv_analysis_cli/src/main.rs
+++ b/riscv_analysis_cli/src/main.rs
@@ -330,7 +330,7 @@ fn main() {
             let mut parser = RVParser::new(reader);
 
             let mut diags = Vec::new();
-            let parsed = parser.parse(
+            let parsed = parser.parse_from_file(
                 lint.input
                     .to_str()
                     .expect("unable to convert path to string"),
@@ -368,7 +368,7 @@ fn main() {
         Commands::Fix(fix) => {
             let reader = IOFileReader::new();
             let mut parser = RVParser::new(reader);
-            let parsed = parser.parse(
+            let parsed = parser.parse_from_file(
                 fix.input
                     .to_str()
                     .expect("unable to convert path to string"),
@@ -390,7 +390,7 @@ fn main() {
             // Debug mode that prints out parsing errors only
             let reader = IOFileReader::new();
             let mut parser = RVParser::new(reader);
-            let parsed = parser.parse(
+            let parsed = parser.parse_from_file(
                 debu.input
                     .to_str()
                     .expect("unable to convert path to string"),
@@ -435,7 +435,7 @@ mod tests {
                 let reader = IOFileReader::new();
                 let mut parser = RVParser::new(reader);
 
-                let parsed = parser.parse(filename, false);
+                let parsed = parser.parse_from_file(filename, false);
 
                 let res: Cfg = Manager::gen_full_cfg(parsed.0).unwrap();
                 let res = CfgWrapper::from(&res);

--- a/riscv_analysis_cli/src/main.rs
+++ b/riscv_analysis_cli/src/main.rs
@@ -1,13 +1,13 @@
 use std::fmt::Display;
 use std::io::Write;
 use std::vec;
-use std::{collections::HashMap, iter::Peekable, str::FromStr};
+use std::{collections::HashMap, str::FromStr};
 
 use bat::line_range::{LineRange, LineRanges};
 use bat::{Input, PrettyPrinter};
 use colored::Colorize;
 use riscv_analysis::fix::{fix_stack, Manipulation};
-use riscv_analysis::parser::{Info, LabelString, Lexer, RVParser, With};
+use riscv_analysis::parser::{Info, LabelString, RVParser, With};
 use riscv_analysis::passes::{DiagnosticItem, SeverityLevel};
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -219,7 +219,7 @@ impl FileReader for IOFileReader {
         &mut self,
         path: &str,
         parent_file: Option<uuid::Uuid>,
-    ) -> Result<(Uuid, Peekable<Lexer>), FileReaderError> {
+    ) -> Result<(Uuid, String), FileReaderError> {
         let path = if let Some(id) = parent_file {
             // get parent from uuid
             let parent = self.files.get(&id).map(|(path, _)| path);
@@ -263,10 +263,7 @@ impl FileReader for IOFileReader {
             return Err(FileReaderError::FileAlreadyRead(path));
         }
 
-        // create lexer
-        let lexer = Lexer::new(file, uuid);
-
-        Ok((uuid, lexer.peekable()))
+        Ok((uuid, file))
     }
 }
 

--- a/riscv_analysis_cli/src/main.rs
+++ b/riscv_analysis_cli/src/main.rs
@@ -218,9 +218,9 @@ impl FileReader for IOFileReader {
     fn import_file(
         &mut self,
         path: &str,
-        in_file: Option<uuid::Uuid>,
+        parent_file: Option<uuid::Uuid>,
     ) -> Result<(Uuid, Peekable<Lexer>), FileReaderError> {
-        let path = if let Some(id) = in_file {
+        let path = if let Some(id) = parent_file {
             // get parent from uuid
             let parent = self.files.get(&id).map(|(path, _)| path);
             if let Some(parent) = parent {

--- a/riscv_analysis_lsp/src/lib.rs
+++ b/riscv_analysis_lsp/src/lib.rs
@@ -44,7 +44,7 @@ where
     /// Return the imported files of a file
     fn get_imports(&mut self, base: &str) -> HashSet<String> {
         let mut imported = HashSet::new();
-        let items = self.parse(base, true);
+        let items = self.parse_from_file(base, true);
         for item in items.0 {
             if let ParserNode::Directive(x) = item {
                 if let DirectiveType::Include(name) = x.dir {

--- a/riscv_analysis_lsp/src/lsp/mod.rs
+++ b/riscv_analysis_lsp/src/lsp/mod.rs
@@ -123,10 +123,10 @@ impl FileReader for LSPFileReader {
     fn import_file(
         &mut self,
         path: &str,
-        in_file: Option<uuid::Uuid>,
+        parent_file: Option<uuid::Uuid>,
     ) -> Result<(Uuid, Peekable<Lexer>), FileReaderError> {
-        // if there is an in_file, find its path and use that as the parent
-        let fulluri = match in_file {
+        // if there is an parent_file, find its path and use that as the parent
+        let fulluri = match parent_file {
             Some(uuid) => {
                 let doc = self.file_uris.get(&uuid).unwrap();
                 let uri = lsp_types::Url::parse(&doc.uri).unwrap();

--- a/riscv_analysis_lsp/src/lsp/mod.rs
+++ b/riscv_analysis_lsp/src/lsp/mod.rs
@@ -1,15 +1,13 @@
 // Type conversions for LSP
 
-use std::collections::HashMap;
-use std::iter::Peekable;
-
 use lsp_types::{
     Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Location, Position, Range,
 };
-use riscv_analysis::parser::{CanGetURIString, Lexer, RVDocument, RVParser, Range as MyRange};
+use riscv_analysis::parser::{CanGetURIString, RVDocument, RVParser, Range as MyRange};
 use riscv_analysis::passes::DiagnosticItem;
 use riscv_analysis::passes::SeverityLevel;
 use riscv_analysis::reader::{FileReader, FileReaderError};
+use std::collections::HashMap;
 
 mod completion;
 pub use completion::*;
@@ -124,7 +122,7 @@ impl FileReader for LSPFileReader {
         &mut self,
         path: &str,
         parent_file: Option<uuid::Uuid>,
-    ) -> Result<(Uuid, Peekable<Lexer>), FileReaderError> {
+    ) -> Result<(Uuid, String), FileReaderError> {
         // if there is an parent_file, find its path and use that as the parent
         let fulluri = match parent_file {
             Some(uuid) => {
@@ -151,8 +149,7 @@ impl FileReader for LSPFileReader {
 
         // if file found, return lexer
         let doc = doc.unwrap();
-        let lexer = Lexer::new(&doc.1.text, doc.0);
-        Ok((doc.0, lexer.peekable()))
+        Ok((doc.0, doc.1.text))
     }
 }
 


### PR DESCRIPTION
**Summary**: This PR introduces a new type and method `RVStringParser::parse_from_text(&str)` to generate parser nodes from raw text. Since the parsing is currently very coupled to reading files, due to the `.include` directive, these changes introduce a no-op reader `EmptyFileReader` to implement this without many changes to the underlying architecture. It still has room for a lot of improvements down the line.

**Test plan**: The new types include both doc-tests and traditional unit tests to test the basic functionality. All renaming changes don't have tests associated as they do not change any functionality.