### PR TITLE
[RV-29] Rename WarningLevel to SeverityLevel

### DIFF
--- a/riscv_analysis/src/parser/error.rs
+++ b/riscv_analysis/src/parser/error.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use uuid::Uuid;
 
 use crate::{
-    passes::{DiagnosticLocation, DiagnosticMessage, WarningLevel},
+    passes::{DiagnosticLocation, DiagnosticMessage, SeverityLevel},
     reader::FileReaderError,
 };
 
@@ -88,7 +88,7 @@ impl DiagnosticMessage for ParseError {
     fn related(&self) -> Option<Vec<crate::passes::RelatedDiagnosticItem>> {
         None
     }
-    fn level(&self) -> WarningLevel {
+    fn level(&self) -> SeverityLevel {
         self.into()
     }
     fn title(&self) -> String {
@@ -174,7 +174,7 @@ impl DiagnosticLocation for ParseError {
     }
 }
 
-impl From<&ParseError> for WarningLevel {
+impl From<&ParseError> for SeverityLevel {
     fn from(e: &ParseError) -> Self {
         match e {
             ParseError::Expected(_, _)
@@ -184,7 +184,7 @@ impl From<&ParseError> for WarningLevel {
             | ParseError::UnknownDirective(_)
             | ParseError::CyclicDependency(_)
             | ParseError::FileNotFound(_)
-            | ParseError::IOError(_, _) => WarningLevel::Error,
+            | ParseError::IOError(_, _) => SeverityLevel::Error,
         }
     }
 }

--- a/riscv_analysis/src/passes/cfg_error.rs
+++ b/riscv_analysis/src/passes/cfg_error.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, fmt::Display};
 
 use crate::parser::{LabelString, ParserNode, With};
 
-use super::{DiagnosticLocation, DiagnosticMessage, WarningLevel};
+use super::{DiagnosticLocation, DiagnosticMessage, SeverityLevel};
 
 #[derive(Debug, Clone)]
 // TODO CfgErrors that do not require the whole thing to be re-run
@@ -75,7 +75,7 @@ impl Display for CfgError {
     }
 }
 
-impl From<&CfgError> for WarningLevel {
+impl From<&CfgError> for SeverityLevel {
     fn from(value: &CfgError) -> Self {
         match value {
             CfgError::LabelsNotDefined(_)
@@ -84,7 +84,7 @@ impl From<&CfgError> for WarningLevel {
             | CfgError::NoLabelForReturn(_)
             | CfgError::UnexpectedError
             | CfgError::OverlappingFunctions(_, _)
-            | CfgError::AssertionError => WarningLevel::Error,
+            | CfgError::AssertionError => SeverityLevel::Error,
         }
     }
 }
@@ -122,7 +122,7 @@ impl DiagnosticMessage for CfgError {
         None
     }
 
-    fn level(&self) -> WarningLevel {
+    fn level(&self) -> SeverityLevel {
         self.into()
     }
     fn title(&self) -> String {

--- a/riscv_analysis/src/passes/diagnostics.rs
+++ b/riscv_analysis/src/passes/diagnostics.rs
@@ -2,7 +2,7 @@ use uuid::Uuid;
 
 use crate::parser::Range;
 
-use super::WarningLevel;
+use super::SeverityLevel;
 
 pub trait DiagnosticLocation {
     fn range(&self) -> Range;
@@ -13,7 +13,7 @@ pub trait DiagnosticMessage {
     fn title(&self) -> String;
     fn description(&self) -> String;
     fn long_description(&self) -> String;
-    fn level(&self) -> WarningLevel;
+    fn level(&self) -> SeverityLevel;
     fn related(&self) -> Option<Vec<RelatedDiagnosticItem>>;
 }
 
@@ -30,7 +30,7 @@ pub struct DiagnosticItem {
     pub title: String,
     pub description: String,
     pub long_description: String,
-    pub level: WarningLevel,
+    pub level: SeverityLevel,
     pub related: Option<Vec<RelatedDiagnosticItem>>,
 }
 

--- a/riscv_analysis/src/passes/lint_error.rs
+++ b/riscv_analysis/src/passes/lint_error.rs
@@ -52,12 +52,12 @@ pub enum LintError {
 }
 
 #[derive(Clone)]
-pub enum WarningLevel {
+pub enum SeverityLevel {
     Warning,
     Error,
 }
 
-impl From<&LintError> for WarningLevel {
+impl From<&LintError> for SeverityLevel {
     fn from(val: &LintError) -> Self {
         match val {
             LintError::DeadAssignment(_)
@@ -66,7 +66,7 @@ impl From<&LintError> for WarningLevel {
             | LintError::InvalidJumpToFunction(..)
             | LintError::FirstInstructionIsFunction(..)
             | LintError::LostRegisterValue(_)
-            | LintError::UnreachableCode(_) => WarningLevel::Warning,
+            | LintError::UnreachableCode(_) => SeverityLevel::Warning,
             LintError::UnknownEcall(_)
             | LintError::InvalidUseAfterCall(..)
             | LintError::InvalidUseBeforeAssignment(_)
@@ -74,7 +74,7 @@ impl From<&LintError> for WarningLevel {
             | LintError::InvalidStackPointer(_)
             | LintError::InvalidStackPosition(_, _)
             | LintError::InvalidStackOffsetUsage(_, _)
-            | LintError::OverwriteCalleeSavedRegister(_) => WarningLevel::Error,
+            | LintError::OverwriteCalleeSavedRegister(_) => SeverityLevel::Error,
         }
     }
 }
@@ -135,7 +135,7 @@ impl std::fmt::Display for LintError {
 }
 
 impl DiagnosticMessage for LintError {
-    fn level(&self) -> WarningLevel {
+    fn level(&self) -> SeverityLevel {
         self.into()
     }
     fn title(&self) -> String {

--- a/riscv_analysis_cli/src/main.rs
+++ b/riscv_analysis_cli/src/main.rs
@@ -8,7 +8,7 @@ use bat::{Input, PrettyPrinter};
 use colored::Colorize;
 use riscv_analysis::fix::{fix_stack, Manipulation};
 use riscv_analysis::parser::{Info, LabelString, Lexer, RVParser, With};
-use riscv_analysis::passes::{DiagnosticItem, WarningLevel};
+use riscv_analysis::passes::{DiagnosticItem, SeverityLevel};
 use std::path::PathBuf;
 use uuid::Uuid;
 
@@ -284,8 +284,8 @@ impl ErrorDisplay for Vec<DiagnosticItem> {
             let text = parser.reader.get_text(err.file).unwrap();
 
             let level = match err.level {
-                WarningLevel::Warning => "WARNING",
-                WarningLevel::Error => "ERROR",
+                SeverityLevel::Warning => "WARNING",
+                SeverityLevel::Error => "ERROR",
             };
 
             PrettyPrinter::new()

--- a/riscv_analysis_lsp/src/lsp/mod.rs
+++ b/riscv_analysis_lsp/src/lsp/mod.rs
@@ -8,7 +8,7 @@ use lsp_types::{
 };
 use riscv_analysis::parser::{CanGetURIString, Lexer, RVDocument, RVParser, Range as MyRange};
 use riscv_analysis::passes::DiagnosticItem;
-use riscv_analysis::passes::WarningLevel;
+use riscv_analysis::passes::SeverityLevel;
 use riscv_analysis::reader::{FileReader, FileReaderError};
 
 mod completion;
@@ -40,11 +40,11 @@ trait WarningInto {
     fn to_severity(&self) -> DiagnosticSeverity;
 }
 
-impl WarningInto for WarningLevel {
+impl WarningInto for SeverityLevel {
     fn to_severity(&self) -> DiagnosticSeverity {
         match self {
-            WarningLevel::Warning => DiagnosticSeverity::WARNING,
-            WarningLevel::Error => DiagnosticSeverity::ERROR,
+            SeverityLevel::Warning => DiagnosticSeverity::WARNING,
+            SeverityLevel::Error => DiagnosticSeverity::ERROR,
         }
     }
 }


### PR DESCRIPTION
**Summary**: 

Rename the lint type `WarningLevel` to `SeverityLevel` to match the LSP documentation. In the future, the Hint & Informations types will be added.

**Test plan**: 

No functionality was changed.
