### PR TITLE
[RV-30] Add Information & Hint types to Severity Helper

### DIFF
--- a/riscv_analysis/src/passes/lint_error.rs
+++ b/riscv_analysis/src/passes/lint_error.rs
@@ -53,8 +53,10 @@ pub enum LintError {
 
 #[derive(Clone)]
 pub enum SeverityLevel {
-    Warning,
     Error,
+    Warning,
+    Information,
+    Hint,
 }
 
 impl From<&LintError> for SeverityLevel {

--- a/riscv_analysis_cli/src/main.rs
+++ b/riscv_analysis_cli/src/main.rs
@@ -284,8 +284,10 @@ impl ErrorDisplay for Vec<DiagnosticItem> {
             let text = parser.reader.get_text(err.file).unwrap();
 
             let level = match err.level {
-                SeverityLevel::Warning => "WARNING",
                 SeverityLevel::Error => "ERROR",
+                SeverityLevel::Warning => "WARNING",
+                SeverityLevel::Information => "INFO",
+                SeverityLevel::Hint => "HINT",
             };
 
             PrettyPrinter::new()

--- a/riscv_analysis_lsp/src/lsp/mod.rs
+++ b/riscv_analysis_lsp/src/lsp/mod.rs
@@ -43,8 +43,10 @@ trait WarningInto {
 impl WarningInto for SeverityLevel {
     fn to_severity(&self) -> DiagnosticSeverity {
         match self {
-            SeverityLevel::Warning => DiagnosticSeverity::WARNING,
             SeverityLevel::Error => DiagnosticSeverity::ERROR,
+            SeverityLevel::Warning => DiagnosticSeverity::WARNING,
+            SeverityLevel::Information => DiagnosticSeverity::INFORMATION,
+            SeverityLevel::Hint => DiagnosticSeverity::HINT,
         }
     }
 }


### PR DESCRIPTION
**Summary**: 

Add Information and hint levels to the lint severity levels.

**Test plan**: 

The new levels are not used by any non-printing code.
