### PR TITLE
[RV-5] Detect Overlapping Function & Print a Warning

### DIFF
--- a/riscv_analysis/src/lints/mod.rs
+++ b/riscv_analysis/src/lints/mod.rs
@@ -3,3 +3,6 @@ pub use checks::*;
 
 mod instruction_in_text;
 pub use instruction_in_text::*;
+
+mod overlapping_function;
+pub use overlapping_function::*;

--- a/riscv_analysis/src/lints/overlapping_function.rs
+++ b/riscv_analysis/src/lints/overlapping_function.rs
@@ -1,0 +1,29 @@
+use crate::{
+    cfg::Cfg,
+    passes::{LintError, LintPass},
+};
+
+/// A lint to ensure warn about instructions that exist in more than one
+/// function.
+///
+/// Though it is technically correct to have overlapping functions, this pattern
+/// doesn't generally occur in canonical code. Instead, the existence of
+/// overlapping functions usually indicates a mistaken jump to the middle of a
+/// function.
+pub struct OverlappingFunctionCheck;
+impl LintPass for OverlappingFunctionCheck {
+    fn run(cfg: &Cfg, errors: &mut Vec<LintError>) {
+        for node in &cfg.clone().nodes {
+            // Capture entry points that are part of more than one function
+            if node.functions().len() > 1 && node.is_function_entry().is_some() {
+                errors.push(LintError::OverlappingFunctions(
+                    node.node().clone(),
+                    node.functions()
+                        .clone()
+                        .into_iter()
+                        .collect::<Vec<_>>(),
+                ));
+            }
+        }
+    }
+}

--- a/riscv_analysis/src/lints/overlapping_function.rs
+++ b/riscv_analysis/src/lints/overlapping_function.rs
@@ -34,7 +34,7 @@ impl LintPass for OverlappingFunctionCheck {
 #[cfg(test)]
 mod tests {
     use crate::lints::OverlappingFunctionCheck;
-    use crate::parser::RVStringParser;
+    use crate::parser::{ParserNode, RVStringParser};
     use crate::passes::{LintError, LintPass, Manager};
 
     /// Compute the lints for a given input
@@ -65,7 +65,14 @@ mod tests {
         let lints = run_pass(input);
 
         assert_eq!(lints.len(), 1);
-        assert!(matches!(&lints[0], LintError::NodeInManyFunctions(..)));
+        assert!(matches!(
+            &lints[0], LintError::NodeInManyFunctions(node, _)
+                if matches!(
+                    node, ParserNode::FuncEntry(entry)
+                        if entry.token.text == "addi a0 a0 2"
+                )
+            )
+        );
     }
 
     #[test]
@@ -90,8 +97,22 @@ mod tests {
         let lints = run_pass(input);
 
         assert_eq!(lints.len(), 2);
-        assert!(matches!(&lints[0], LintError::NodeInManyFunctions(..)));
-        assert!(matches!(&lints[1], LintError::NodeInManyFunctions(..)));
+        assert!(matches!(
+            &lints[0], LintError::NodeInManyFunctions(node, _)
+                if matches!(
+                    node, ParserNode::FuncEntry(entry)
+                        if entry.token.text == "addi a0 a0 2"
+                )
+            )
+        );
+        assert!(matches!(
+            &lints[1], LintError::NodeInManyFunctions(node, _)
+                if matches!(
+                    node, ParserNode::FuncEntry(entry)
+                        if entry.token.text == "addi a0 a0 3"
+                )
+            )
+        );
     }
 
     #[test]

--- a/riscv_analysis/src/lints/overlapping_function.rs
+++ b/riscv_analysis/src/lints/overlapping_function.rs
@@ -16,7 +16,7 @@ impl LintPass for OverlappingFunctionCheck {
         for node in &cfg.clone().nodes {
             // Capture entry points that are part of more than one function
             if node.functions().len() > 1 && node.is_function_entry().is_some() {
-                errors.push(LintError::OverlappingFunctions(
+                errors.push(LintError::NodeInManyFunctions(
                     node.node().clone(),
                     node.functions()
                         .clone()
@@ -62,7 +62,7 @@ mod tests {
         let lints = run_pass(input);
 
         assert_eq!(lints.len(), 1);
-        assert!(matches!(&lints[0], LintError::OverlappingFunctions(..)));
+        assert!(matches!(&lints[0], LintError::NodeInManyFunctions(..)));
     }
 
     #[test]
@@ -87,8 +87,8 @@ mod tests {
         let lints = run_pass(input);
 
         assert_eq!(lints.len(), 2);
-        assert!(matches!(&lints[0], LintError::OverlappingFunctions(..)));
-        assert!(matches!(&lints[1], LintError::OverlappingFunctions(..)));
+        assert!(matches!(&lints[0], LintError::NodeInManyFunctions(..)));
+        assert!(matches!(&lints[1], LintError::NodeInManyFunctions(..)));
     }
 
     #[test]

--- a/riscv_analysis/src/lints/overlapping_function.rs
+++ b/riscv_analysis/src/lints/overlapping_function.rs
@@ -15,6 +15,9 @@ impl LintPass for OverlappingFunctionCheck {
     fn run(cfg: &Cfg, errors: &mut Vec<LintError>) {
         for node in &cfg.clone().nodes {
             // Capture entry points that are part of more than one function
+            // NOTE: We only give an error for the first line of a function,
+            //       even though there may be many overlapping instructions.
+            //       This is done to not overwhelm the user with errors.
             if node.functions().len() > 1 && node.is_function_entry().is_some() {
                 errors.push(LintError::NodeInManyFunctions(
                     node.node().clone(),

--- a/riscv_analysis/src/passes/lint_error.rs
+++ b/riscv_analysis/src/passes/lint_error.rs
@@ -10,6 +10,8 @@ use crate::parser::Range;
 use crate::parser::Register;
 use crate::parser::With;
 
+use itertools::Itertools;
+
 use super::DiagnosticLocation;
 use super::DiagnosticMessage;
 
@@ -140,7 +142,6 @@ impl std::fmt::Display for LintError {
                 write!(f, "Part of multiple functions: {}",
                        funcs.iter()
                        .map(|fun| fun.name().0)
-                       .collect::<Vec<_>>()
                        .join(" | ")
                 )
             }

--- a/riscv_analysis/src/passes/lint_error.rs
+++ b/riscv_analysis/src/passes/lint_error.rs
@@ -51,7 +51,7 @@ pub enum LintError {
                                      // AnyJumpToData -- if any jump is to a data label, then it is a warning (label strings should have data/text prefix)
 
     /// An instruction is a member of more than one function.
-    OverlappingFunctions(ParserNode, Vec<Rc<Function>>)
+    NodeInManyFunctions(ParserNode, Vec<Rc<Function>>)
 }
 
 #[derive(Clone)]
@@ -71,7 +71,7 @@ impl From<&LintError> for SeverityLevel {
             | LintError::InvalidJumpToFunction(..)
             | LintError::FirstInstructionIsFunction(..)
             | LintError::LostRegisterValue(_)
-            | LintError::OverlappingFunctions(..)
+            | LintError::NodeInManyFunctions(..)
             | LintError::UnreachableCode(_) => SeverityLevel::Warning,
             LintError::UnknownEcall(_)
             | LintError::InvalidUseAfterCall(..)
@@ -136,7 +136,7 @@ impl std::fmt::Display for LintError {
                     i.abs()
                 )
             }
-            LintError::OverlappingFunctions(_node, funcs) => {
+            LintError::NodeInManyFunctions(_node, funcs) => {
                 write!(f, "Part of multiple functions: {}",
                        funcs.iter()
                        .map(|fun| fun.name().0)
@@ -223,7 +223,7 @@ impl DiagnosticLocation for LintError {
             | LintError::UnknownStack(r)
             | LintError::InvalidStackPointer(r)
             | LintError::InvalidStackOffsetUsage(r, _)
-            | LintError::OverlappingFunctions(r, _)
+            | LintError::NodeInManyFunctions(r, _)
             | LintError::InvalidStackPosition(r, _) => r.range(),
         }
     }
@@ -244,7 +244,7 @@ impl DiagnosticLocation for LintError {
             | LintError::UnknownStack(r)
             | LintError::InvalidStackPointer(r)
             | LintError::InvalidStackOffsetUsage(r, _)
-            | LintError::OverlappingFunctions(r, _)
+            | LintError::NodeInManyFunctions(r, _)
             | LintError::InvalidStackPosition(r, _) => r.file(),
         }
     }

--- a/riscv_analysis/src/passes/manager.rs
+++ b/riscv_analysis/src/passes/manager.rs
@@ -7,8 +7,8 @@ use crate::{
     },
     lints::{
         CalleeSavedGarbageReadCheck, CalleeSavedRegisterCheck, ControlFlowCheck, DeadValueCheck,
-        EcallCheck, GarbageInputValueCheck, InstructionInTextCheck, LostCalleeSavedRegisterCheck,
-        SaveToZeroCheck, StackCheckPass,
+        EcallCheck, GarbageInputValueCheck, InstructionInTextCheck, LostCalleeSavedRegisterCheck, SaveToZeroCheck,
+        StackCheckPass, OverlappingFunctionCheck,
     },
     parser::ParserNode,
 };
@@ -49,6 +49,7 @@ impl Manager {
         CalleeSavedRegisterCheck::run(cfg, errors);
         CalleeSavedGarbageReadCheck::run(cfg, errors);
         LostCalleeSavedRegisterCheck::run(cfg, errors);
+        OverlappingFunctionCheck::run(cfg, errors);
     }
     pub fn run(cfg: Vec<ParserNode>) -> Result<Vec<LintError>, Box<CfgError>> {
         let mut errors = Vec::new();

--- a/riscv_analysis/src/passes/pass.rs
+++ b/riscv_analysis/src/passes/pass.rs
@@ -40,8 +40,13 @@ pub trait LintPass {
     #[must_use]
     fn run_single_pass_along_nodes(nodes: &[ParserNode]) -> Vec<LintError> {
         let cfg = Cfg::new(nodes.into()).unwrap();
+        Self::run_single_pass_along_cfg(&cfg)
+    }
+
+    #[must_use]
+    fn run_single_pass_along_cfg(cfg: &Cfg) -> Vec<LintError> {
         let mut errors = Vec::new();
-        Self::run(&cfg, &mut errors);
+        Self::run(cfg, &mut errors);
         errors
     }
 }


### PR DESCRIPTION
**Summary**: 

Detect instructions that belong to more than one function. Though this pattern is "technically correct" assembly, it doesn't generally occur in real assembly code. More likely, there is an erroneous jump to the middle of a function. Thus the user should be notified of any such occurrences.

**Test plan**: 

Unit tests have been added.

