### PR TITLE
[RV-27] fix: comment tokens are incorrectly marked as an unsupported operation

### DIFF
--- a/riscv_analysis/src/parser/comments.rs
+++ b/riscv_analysis/src/parser/comments.rs
@@ -1,0 +1,15 @@
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ParserNode, RVStringParser};
+
+    #[test]
+    fn can_parse_comments_without_errors() {
+        let (nodes, errors) =
+            RVStringParser::parse_from_text("add x1, x10, x11 #this is my comment\n");
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(errors.len(), 0);
+        matches!(&nodes[0], ParserNode::ProgramEntry(_));
+        matches!(&nodes[1], ParserNode::Arith(_));
+        assert_eq!(nodes[1].to_string(), "add ra <- a0, a1");
+    }
+}

--- a/riscv_analysis/src/parser/error.rs
+++ b/riscv_analysis/src/parser/error.rs
@@ -18,7 +18,7 @@ use super::{Info, ParserNode, With};
 pub enum LexError {
     Expected(Vec<ExpectedType>, Info),
     IsNewline(Info),
-    Ignored(Info),
+    IgnoredWithWarning(Info),
     UnexpectedToken(Info),
     UnexpectedEOF,
     NeedTwoNodes(Box<ParserNode>, Box<ParserNode>),

--- a/riscv_analysis/src/parser/error.rs
+++ b/riscv_analysis/src/parser/error.rs
@@ -19,6 +19,7 @@ pub enum LexError {
     Expected(Vec<ExpectedType>, Info),
     IsNewline(Info),
     IgnoredWithWarning(Info),
+    IgnoredWithoutWarning,
     UnexpectedToken(Info),
     UnexpectedEOF,
     NeedTwoNodes(Box<ParserNode>, Box<ParserNode>),

--- a/riscv_analysis/src/parser/mod.rs
+++ b/riscv_analysis/src/parser/mod.rs
@@ -44,3 +44,5 @@ pub use empty_file_reader::*;
 
 mod rv_string_parser;
 pub use rv_string_parser::*;
+
+mod comments;

--- a/riscv_analysis/src/parser/parsing.rs
+++ b/riscv_analysis/src/parser/parsing.rs
@@ -177,7 +177,7 @@ impl<T: FileReader + Clone> RVParser<T> {
                         parse_errors.push(ParseError::UnknownDirective(y));
                         self.recover_from_parse_error();
                     }
-                    LexError::Ignored(y) | LexError::UnsupportedDirective(y) => {
+                    LexError::IgnoredWithWarning(y) | LexError::UnsupportedDirective(y) => {
                         parse_errors.push(ParseError::Unsupported(y));
                         self.recover_from_parse_error();
                     }
@@ -297,7 +297,7 @@ impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
 
     #[allow(clippy::too_many_lines)]
     fn try_from(val: &mut Peekable<Lexer>) -> Result<Self, Self::Error> {
-        use LexError::{Expected, Ignored, IsNewline, NeedTwoNodes};
+        use LexError::{Expected, IgnoredWithWarning, IsNewline, NeedTwoNodes};
 
         let mut lex = AnnotatedLexer {
             lexer: val,
@@ -603,7 +603,7 @@ impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
                                 lex.raw_token,
                             ))
                         }
-                        Type::Ignore(_) => Err(Ignored(next_node)),
+                        Type::Ignore(_) => Err(IgnoredWithWarning(next_node)),
                         Type::Basic(inst) => Ok(ParserNode::new_basic(
                             With::new(inst, next_node),
                             lex.raw_token,
@@ -1010,9 +1010,9 @@ impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
                                     }
                                 }
                             }
-                            Err(LexError::Ignored(next_node))
+                            Err(LexError::IgnoredWithWarning(next_node))
                         }
-                        DirectiveToken::EndMacro => Err(LexError::Ignored(next_node)),
+                        DirectiveToken::EndMacro => Err(LexError::IgnoredWithWarning(next_node)),
                         DirectiveToken::Section
                         | DirectiveToken::Extern
                         | DirectiveToken::Eqv
@@ -1049,8 +1049,7 @@ impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
                 Err(LexError::UnexpectedToken(next_node))
             }
             // Skip comment token
-            Token::Comment(_) => Err(LexError::Ignored(next_node))
-
+            Token::Comment(_) => Err(LexError::IgnoredWithWarning(next_node)),
         }
     }
 }

--- a/riscv_analysis/src/parser/parsing.rs
+++ b/riscv_analysis/src/parser/parsing.rs
@@ -181,6 +181,7 @@ impl<T: FileReader + Clone> RVParser<T> {
                         parse_errors.push(ParseError::Unsupported(y));
                         self.recover_from_parse_error();
                     }
+                    LexError::IgnoredWithoutWarning => (),
                 },
             }
         }

--- a/riscv_analysis/src/parser/parsing.rs
+++ b/riscv_analysis/src/parser/parsing.rs
@@ -1050,7 +1050,7 @@ impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
                 Err(LexError::UnexpectedToken(next_node))
             }
             // Skip comment token
-            Token::Comment(_) => Err(LexError::IgnoredWithWarning(next_node)),
+            Token::Comment(_) => Err(LexError::IgnoredWithoutWarning),
         }
     }
 }


### PR DESCRIPTION
**Summary**: This PR fixes 2 bugs; it prevents a token from being created across two lines, causing a panic when the column numbers were subtracted. In addition, it also fixes a bug where all comments were marked as unsupported operations.

**Test plan**: For bug 1, a `debug_assert!` was inserted to ensure that this case will never be available (in the future, I'd like to move this logic/design to the creation of a `Token`). For bug 2, a unit test was added.