### PR TITLE
[RV-45] Fix unreachable directive bug

### DIFF
--- a/riscv_analysis/src/cfg/graph.rs
+++ b/riscv_analysis/src/cfg/graph.rs
@@ -132,6 +132,8 @@ impl Cfg {
                 ParserNode::Directive(x) if x.dir == DirectiveType::TextSection => {
                     segment = Segment::Text;
                 }
+                // Ignore other types of directives
+                ParserNode::Directive(_) => {},
                 _ => {
                     // If any of the labels are a function call, add a function entry node
                     if current_labels

--- a/riscv_analysis/src/lints/control_flow.rs
+++ b/riscv_analysis/src/lints/control_flow.rs
@@ -66,7 +66,7 @@ mod tests {
         let (nodes, error) = RVStringParser::parse_from_text(input);
         assert_eq!(error.len(), 0);
 
-        let cfg = Manager::gen_full_cfg(nodes).unwrap(); // Need fn annotations
+        let cfg = Manager::gen_full_cfg(nodes).unwrap();
         ControlFlowCheck::run_single_pass_along_cfg(&cfg)
     }
 
@@ -173,6 +173,29 @@ mod tests {
         let lints = run_pass(input);
 
         // Overlapping functions should not cause a control flow error
+        assert_eq!(lints.len(), 0);
+    }
+
+
+    #[test]
+    fn unreachable_directive() {
+        let input = "\
+            .text                      \n\
+            main:                      \n\
+                jal     fn_a           \n\
+                la      a0, bytes      \n\
+                lw      a0, 0(a0)      \n\
+                addi    a7, zero, 10   \n\
+                ecall                  \n\
+            fn_a:                      \n\
+                addi    a0, a0, 1      \n\
+                ret                    \n\
+            .data                      \n\
+            bytes:   .space 10         \n";
+
+        let lints = run_pass(input);
+
+        // An "unreachable" directive shouldn't cause an error
         assert_eq!(lints.len(), 0);
     }
 }


### PR DESCRIPTION
**Summary**: 

Come CFG nodes were being created for directives, causing issues with the unreachable code detection lint. To fix this, all directives now don't generate CFG nodes.

**Test plan**: 

A test was added to the unreachable code lint.
