### PR TITLE
[RV-59] Fix substraction underflow on empty CFG

### DIFF
--- a/riscv_analysis/src/cfg/iterator.rs
+++ b/riscv_analysis/src/cfg/iterator.rs
@@ -225,3 +225,26 @@ impl Iterator for CfgPrevsIterator {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::cfg::Cfg;
+    use crate::parser::RVStringParser;
+
+    /// Generate the complete CFG from an input string.
+    fn gen_cfg(input: &str) -> Cfg {
+        let (nodes, error) = RVStringParser::parse_from_text(input);
+        assert_eq!(error.len(), 0);
+        Cfg::new(nodes).unwrap()
+    }
+
+    #[test]
+    fn empty() {
+        let input = "";
+        let cfg = gen_cfg(input);
+        let mut iterator = cfg.iter();
+
+        iterator.next(); // There is a program entry node by default
+        assert_eq!(iterator.next(), None);
+    }
+}

--- a/riscv_analysis/src/cfg/iterator.rs
+++ b/riscv_analysis/src/cfg/iterator.rs
@@ -16,11 +16,20 @@ impl<'a> CfgIterator<'a> {
     #[must_use]
     pub fn new(cfg: &'a Cfg) -> Self {
         let nodes = &cfg.nodes();
+        let mut end_final = false;
+        let end = match nodes.len() {
+            0 => {
+                end_final = true;
+                0
+            },
+            l => l - 1,
+        };
+
         Self {
             nodes,
             start: 0,
-            end: nodes.len() - 1,
-            end_final: false,
+            end,
+            end_final,
         }
     }
 


### PR DESCRIPTION
**Summary**: 

The CFG iterator causes a subtraction underflow if the CFG has zero nodes. This is fixed by doing a check to see if the CFG is empty.

**Test plan**: 

TODO
