### PR TITLE
[RV-60] Fix MathOp to have the correct behaviour for division / remainder by 0

### DIFF
--- a/riscv_analysis/src/cfg/ops.rs
+++ b/riscv_analysis/src/cfg/ops.rs
@@ -84,10 +84,37 @@ impl MathOp {
                 let (x, y) = (x as u64, y as u64);
                 ((x * y) >> 32) as i32
             }
-            MathOp::Div => x / y,
-            MathOp::Divu => (x as u32 / y as u32) as i32,
-            MathOp::Rem => x % y,
-            MathOp::Remu => (x as u32 % y as u32) as i32,
+            // NOTE: The RISC-V spec doesn't trap for integer division by zero,
+            // instead, RISC-V returns the following results for x / 0 (or x % 0):
+            // - div   -1
+            // - divu: 2^32 - 1
+            // - rem:  x
+            // - remu: x
+            MathOp::Div => {
+                match y {
+                    0 => -1,    // 2^32 - 1 as i32
+                    _ => x / y,
+                }
+            },
+            MathOp::Divu => {
+                match y {
+                    0 => -1,
+                    _ => (x as u32 / y as u32) as i32,
+                }
+
+            }
+            MathOp::Rem => {
+                match y {
+                    0 => x,
+                    _ => x % y,
+                }
+            },
+            MathOp::Remu => {
+                match y {
+                    0 => x,
+                    _ => (x as u32 % y as u32) as i32,
+                }
+            }
         }
     }
 }

--- a/riscv_analysis/src/cfg/ops.rs
+++ b/riscv_analysis/src/cfg/ops.rs
@@ -121,12 +121,21 @@ impl MathOp {
 
 #[cfg(test)]
 mod test {
+    use super::MathOp;
+
     #[allow(overflowing_literals)]
     #[test]
     fn bitwise() {
-        use super::MathOp;
         assert_eq!(MathOp::And.operate(0xABCD_EF01, 0x1234_5678), 0x0204_4600);
         assert_eq!(MathOp::Or.operate(0xABCD_EF01, 0x1234_5678), 0xBBFD_FF79);
         assert_eq!(MathOp::Xor.operate(0xABCD_EF01, 0x1234_5678), 0xb9f9_b979);
+    }
+
+    #[test]
+    fn div_zero() {
+        assert_eq!(MathOp::Div.operate(12345678, 0), -1);
+        assert_eq!(MathOp::Divu.operate(12345678, 0), -1);
+        assert_eq!(MathOp::Rem.operate(12345678, 0), 12345678);
+        assert_eq!(MathOp::Remu.operate(12345678, 0), 12345678);
     }
 }


### PR DESCRIPTION
**Summary**: 

Change the results of division / remainder operations to be in line with the spec:

![2024-10-04-1728056179](https://github.com/user-attachments/assets/d94f0fae-3bfd-4c22-8872-263b00411b12)

**Test plan**: 

Added a test for the `div`, `divu`, `rem`, and `remu` operations.
