### PR TITLE
[RV-57] Handle character literals

### DIFF
--- a/riscv_analysis/src/parser/imm.rs
+++ b/riscv_analysis/src/parser/imm.rs
@@ -13,6 +13,7 @@ impl TryFrom<Info> for Imm {
     fn try_from(value: Info) -> Result<Self, Self::Error> {
         match value.token {
             Token::Symbol(s) => Imm::from_str(&s),
+            Token::Char(c) => Ok(Imm(c as i32)),
             _ => Err(()),
         }
     }

--- a/riscv_analysis/src/parser/lexer.rs
+++ b/riscv_analysis/src/parser/lexer.rs
@@ -925,4 +925,15 @@ mod tests {
             )
         ));
     }
+
+    #[test]
+    fn newline_chars() {
+        let input = "'\\n' 'n' \n ";
+        let tokens = tokenize(input);
+
+        assert_eq!(
+            tokens,
+            vec![Token::Char('\n'), Token::Char('n'), Token::Newline]
+        );
+    }
 }

--- a/riscv_analysis/src/parser/parsing.rs
+++ b/riscv_analysis/src/parser/parsing.rs
@@ -1055,7 +1055,7 @@ impl TryFrom<&mut Peekable<Lexer>> for ParserNode {
                 }
             }
             Token::Newline => Err(IsNewline(next_node)),
-            Token::LParen | Token::RParen | Token::String(_) => {
+            Token::LParen | Token::RParen | Token::String(_) | Token::Char(_) => {
                 Err(LexError::UnexpectedToken(next_node))
             }
             // Skip comment token

--- a/riscv_analysis/src/parser/token.rs
+++ b/riscv_analysis/src/parser/token.rs
@@ -74,6 +74,8 @@ pub enum Token {
     Directive(String),
     /// String: text enclosed in double quotes
     String(String),
+    // Char: Single character enclosed in single quotes
+    Char(char),
     /// Comment: text starting with # up until the first newline.
     /// A comment is a line of text that is ignored by
     /// the assembler, but they are useful for human readers.
@@ -92,6 +94,7 @@ impl Token {
             Token::Symbol(s) => s.clone(),
             Token::Directive(d) => format!(".{d}"),
             Token::String(s) => format!("\"{s}\""),
+            Token::Char(c) => format!("'{c}'"),
             Token::Comment(c) => format!("#{c}:"),
         }
     }
@@ -222,6 +225,7 @@ impl Display for Token {
             Token::Symbol(s) => write!(f, "SYMBOL({s})"),
             Token::Directive(s) => write!(f, "DIRECTIVE({s})"),
             Token::String(s) => write!(f, "STRING({s})"),
+            Token::Char(c) => write!(f, "CHAR({c})"),
             Token::Comment(s) => write!(f, "COMMENT{s}"),
             Token::Newline => write!(f, "NEWLINE"),
             Token::LParen => write!(f, "LPAREN"),


### PR DESCRIPTION
**Summary**: 

RARS allows character literals to be used as immediates. Characters are treated as their corresponding integer. For example `li a0, 'a'` is equivalent to `li a0, 97`. In this PR, I add the following features:
- A new character token.
- The lexer produces character tokens for single characters (or escape codes) wrapped in single quotes.
- Character tokens are treated as integers by the parser.

**Test plan**: 

Tests were added to the lexer, testing correct characters, un-closed characters, & invalid escape sequences.
