### PR TITLE
[RV-64] Add a runner for CLI tests

### DIFF
--- a/riscv_analysis_cli/Cargo.toml
+++ b/riscv_analysis_cli/Cargo.toml
@@ -24,6 +24,9 @@ serde_json = "1.0.128"
 bat = "0.23.0"
 colored = "2.0.4"
 
+[dev-dependencies]
+assert_cmd = "2.0.16"
+
 [dependencies.uuid]
 version = "1.3.2"
 features = [

--- a/riscv_analysis_cli/Cargo.toml
+++ b/riscv_analysis_cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 riscv_analysis = { path = "../riscv_analysis", version = "0.1.0-alpha" }
 clap = { version = "4.3.8", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0.128"
 bat = "0.23.0"

--- a/riscv_analysis_cli/src/lib.rs
+++ b/riscv_analysis_cli/src/lib.rs
@@ -2,30 +2,29 @@ pub mod wrapper {
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, Debug)]
-    pub struct ListWrapper {
-        pub diagnostics: Vec<DiagnosticWrapper>,
+    pub struct TestCase {
+        pub diagnostics: Vec<DiagnosticTestCase>,
     }
 
     #[derive(Serialize, Deserialize, Debug)]
-    pub struct DiagnosticWrapper {
+    pub struct DiagnosticTestCase {
         pub file: Option<String>,
         pub title: String,
         pub description: String,
         pub level: String,
-        pub range: RangeWrapper,
+        pub range: RangeTestCase,
     }
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-    pub struct RangeWrapper {
-        pub start: PositionWrapper,
-        pub end: PositionWrapper,
+    pub struct RangeTestCase {
+        pub start: PositionTestCase,
+        pub end: PositionTestCase,
     }
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-    pub struct PositionWrapper {
+    pub struct PositionTestCase {
         pub line: usize,
         pub column: usize,
         pub raw: usize,
     }
-
 }

--- a/riscv_analysis_cli/src/lib.rs
+++ b/riscv_analysis_cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod wrapper {
+    use riscv_analysis::parser::{Position, Range};
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, Debug)]
@@ -26,5 +27,24 @@ pub mod wrapper {
         pub line: usize,
         pub column: usize,
         pub raw: usize,
+    }
+
+    impl From<Position> for PositionTestCase {
+        fn from(value: Position) -> Self {
+            Self {
+                line: value.line,
+                column: value.column,
+                raw: value.raw_index,
+            }
+        }
+    }
+
+    impl From<Range> for RangeTestCase {
+        fn from(value: Range) -> Self {
+            Self {
+                start: value.start.into(),
+                end: value.end.into(),
+            }
+        }
     }
 }

--- a/riscv_analysis_cli/src/lib.rs
+++ b/riscv_analysis_cli/src/lib.rs
@@ -1,0 +1,31 @@
+pub mod wrapper {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct ListWrapper {
+        pub diagnostics: Vec<DiagnosticWrapper>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct DiagnosticWrapper {
+        pub file: Option<String>,
+        pub title: String,
+        pub description: String,
+        pub level: String,
+        pub range: RangeWrapper,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    pub struct RangeWrapper {
+        pub start: PositionWrapper,
+        pub end: PositionWrapper,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    pub struct PositionWrapper {
+        pub line: usize,
+        pub column: usize,
+        pub raw: usize,
+    }
+
+}

--- a/riscv_analysis_cli/src/printer.rs
+++ b/riscv_analysis_cli/src/printer.rs
@@ -8,7 +8,7 @@ use riscv_analysis::passes::{DiagnosticItem, SeverityLevel};
 use riscv_analysis::reader::FileReader;
 use uuid::Uuid;
 
-use riscv_analysis_cli::wrapper::{DiagnosticWrapper, ListWrapper, PositionWrapper, RangeWrapper};
+use riscv_analysis_cli::wrapper::{DiagnosticTestCase, TestCase, PositionTestCase, RangeTestCase};
 
 pub trait ErrorDisplay {
     fn display_errors<T: FileReader + Clone>(&mut self, parser: &RVParser<T>);
@@ -149,7 +149,7 @@ impl JSONPrint {
     }
 
     /// Convert a single diagnostic item to JSON
-    fn wrap_item<T: FileReader + Clone> (&self, parser: &RVParser<T>, item: &DiagnosticItem) -> DiagnosticWrapper {
+    fn wrap_item<T: FileReader + Clone> (&self, parser: &RVParser<T>, item: &DiagnosticItem) -> DiagnosticTestCase {
         // Get the fields
         let path = parser
             .reader
@@ -163,20 +163,20 @@ impl JSONPrint {
             SeverityLevel::Hint => "Hint",
         };
 
-        DiagnosticWrapper {
+        DiagnosticTestCase {
             file: path,
             title: item.title.clone(),
             description: item.description.clone(),
             level: level.to_string(),
-            range: RangeWrapper {
+            range: RangeTestCase {
                 start: self.wrap_position(item.range.start),
                 end: self.wrap_position(item.range.end),
             }
         }
     }
 
-    fn wrap_position(&self, pos: Position) -> PositionWrapper {
-        PositionWrapper {
+    fn wrap_position(&self, pos: Position) -> PositionTestCase {
+        PositionTestCase {
             line: pos.line,
             column: pos.column,
             raw: pos.raw_index,
@@ -194,7 +194,7 @@ impl ErrorDisplay for JSONPrint {
             .collect();
 
         // Print the results
-        let out = ListWrapper { diagnostics: sub };
+        let out = TestCase { diagnostics: sub };
         let text = serde_json::to_string_pretty(&out).unwrap();
         println!("{}", text);
     }

--- a/riscv_analysis_cli/src/printer.rs
+++ b/riscv_analysis_cli/src/printer.rs
@@ -3,12 +3,12 @@ use std::fs;
 
 use colored::Colorize;
 
-use riscv_analysis::parser::{Position, RVParser};
+use riscv_analysis::parser::RVParser;
 use riscv_analysis::passes::{DiagnosticItem, SeverityLevel};
 use riscv_analysis::reader::FileReader;
 use uuid::Uuid;
 
-use riscv_analysis_cli::wrapper::{DiagnosticTestCase, TestCase, PositionTestCase, RangeTestCase};
+use riscv_analysis_cli::wrapper::{DiagnosticTestCase, TestCase};
 
 pub trait ErrorDisplay {
     fn display_errors<T: FileReader + Clone>(&mut self, parser: &RVParser<T>);
@@ -168,18 +168,7 @@ impl JSONPrint {
             title: item.title.clone(),
             description: item.description.clone(),
             level: level.to_string(),
-            range: RangeTestCase {
-                start: self.wrap_position(item.range.start),
-                end: self.wrap_position(item.range.end),
-            }
-        }
-    }
-
-    fn wrap_position(&self, pos: Position) -> PositionTestCase {
-        PositionTestCase {
-            line: pos.line,
-            column: pos.column,
-            raw: pos.raw_index,
+            range: item.range.clone().into(),
         }
     }
 }

--- a/riscv_analysis_cli/src/printer.rs
+++ b/riscv_analysis_cli/src/printer.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 use std::fs;
 
 use colored::Colorize;
-use serde_json::{json, Value};
 
 use riscv_analysis::parser::{Position, RVParser};
 use riscv_analysis::passes::{DiagnosticItem, SeverityLevel};
 use riscv_analysis::reader::FileReader;
 use uuid::Uuid;
+
+use riscv_analysis_cli::wrapper::{DiagnosticWrapper, ListWrapper, PositionWrapper, RangeWrapper};
 
 pub trait ErrorDisplay {
     fn display_errors<T: FileReader + Clone>(&mut self, parser: &RVParser<T>);
@@ -148,12 +149,13 @@ impl JSONPrint {
     }
 
     /// Convert a single diagnostic item to JSON
-    fn to_json<T: FileReader + Clone> (&self, parser: &RVParser<T>, item: &DiagnosticItem) -> Value {
+    fn wrap_item<T: FileReader + Clone> (&self, parser: &RVParser<T>, item: &DiagnosticItem) -> DiagnosticWrapper {
         // Get the fields
         let path = parser
             .reader
             .get_filename(item.file)
-            .map(|f| fs::canonicalize(f).unwrap_or_default());
+            .map(|f| fs::canonicalize(f).unwrap_or_default())
+            .map(|p| p.to_str().unwrap_or_default().to_string());
         let level = match item.level {
             SeverityLevel::Error => "Error",
             SeverityLevel::Warning => "Warning",
@@ -161,25 +163,24 @@ impl JSONPrint {
             SeverityLevel::Hint => "Hint",
         };
 
-        // Convert to JSON
-        json!({
-            "file": path,
-            "title": item.title,
-            "description": item.description,
-            "level": level,
-            "range": {
-                "start" : self.position_to_json(item.range.start),
-                "end" : self.position_to_json(item.range.end),
+        DiagnosticWrapper {
+            file: path,
+            title: item.title.clone(),
+            description: item.description.clone(),
+            level: level.to_string(),
+            range: RangeWrapper {
+                start: self.wrap_position(item.range.start),
+                end: self.wrap_position(item.range.end),
             }
-        })
+        }
     }
 
-    fn position_to_json(&self, pos: Position) -> Value {
-        json!({
-            "line": pos.line,
-            "column": pos.column,
-            "raw": pos.raw_index,
-        })
+    fn wrap_position(&self, pos: Position) -> PositionWrapper {
+        PositionWrapper {
+            line: pos.line,
+            column: pos.column,
+            raw: pos.raw_index,
+        }
     }
 }
 
@@ -189,11 +190,11 @@ impl ErrorDisplay for JSONPrint {
         let sub: Vec<_> = self
             .diagnostics
             .iter()
-            .map(|d| self.to_json(parser, d))
+            .map(|d| self.wrap_item(parser, d))
             .collect();
 
         // Print the results
-        let out = json!({ "diagnostics": sub });
+        let out = ListWrapper { diagnostics: sub };
         let text = serde_json::to_string_pretty(&out).unwrap();
         println!("{}", text);
     }

--- a/riscv_analysis_cli/tests/runner.rs
+++ b/riscv_analysis_cli/tests/runner.rs
@@ -1,4 +1,4 @@
-use riscv_analysis_cli::wrapper::{DiagnosticWrapper, ListWrapper};
+use riscv_analysis_cli::wrapper::{DiagnosticTestCase, TestCase};
 
 use std::fs;
 use std::iter::zip;
@@ -15,7 +15,7 @@ fn file_to_path(path: Option<String>) -> PathBuf {
     absolute(PathBuf::from(path.unwrap())).unwrap()
 }
 
-fn diagnostic_eq(actual: &DiagnosticWrapper, expected: &DiagnosticWrapper) -> bool {
+fn diagnostic_eq(actual: &DiagnosticTestCase, expected: &DiagnosticTestCase) -> bool {
     // Check if the paths refer to the same file, since they may not have equal
     // content. For example /full/to/a.s and a.s could refer to the same file.
     let actual_path = file_to_path(actual.file.clone());
@@ -29,7 +29,7 @@ fn diagnostic_eq(actual: &DiagnosticWrapper, expected: &DiagnosticWrapper) -> bo
         && actual.range == expected.range;
 }
 
-fn output_eq(actual: ListWrapper, expected: ListWrapper) -> bool {
+fn output_eq(actual: TestCase, expected: TestCase) -> bool {
     // There must be the same number of errors
     if actual.diagnostics.len() != expected.diagnostics.len() {
         return false;
@@ -61,10 +61,10 @@ fn run_test(asm: PathBuf, results: PathBuf) {
 
     // Compare outputs
     let out = String::from_utf8(cmd.output().unwrap().stdout).unwrap();
-    let actual: ListWrapper = serde_json::from_str(&out).unwrap();
+    let actual: TestCase = serde_json::from_str(&out).unwrap();
 
     let expected_str = fs::read_to_string(results).unwrap();
-    let expected: ListWrapper = serde_json::from_str(&expected_str).unwrap();
+    let expected: TestCase = serde_json::from_str(&expected_str).unwrap();
 
     assert!(output_eq(actual, expected));
 }

--- a/riscv_analysis_cli/tests/runner.rs
+++ b/riscv_analysis_cli/tests/runner.rs
@@ -1,0 +1,83 @@
+use riscv_analysis_cli::wrapper::{DiagnosticWrapper, ListWrapper};
+
+use std::fs;
+use std::iter::zip;
+use std::path::{absolute, PathBuf};
+use std::env;
+
+use assert_cmd::Command;
+
+fn rva_bin() -> Command {
+   Command::cargo_bin("rva").unwrap()
+}
+
+fn file_to_path(path: Option<String>) -> PathBuf {
+    absolute(PathBuf::from(path.unwrap())).unwrap()
+}
+
+fn diagnostic_eq(actual: &DiagnosticWrapper, expected: &DiagnosticWrapper) -> bool {
+    // Check if the paths refer to the same file, since they may not have equal
+    // content. For example /full/to/a.s and a.s could refer to the same file.
+    let actual_path = file_to_path(actual.file.clone());
+    let expected_path = file_to_path(expected.file.clone());
+
+    // All other fields must be equal
+    return actual.title == expected.title
+        && actual_path == expected_path
+        && actual.description == expected.description
+        && actual.level == expected.level
+        && actual.range == expected.range;
+}
+
+fn output_eq(actual: ListWrapper, expected: ListWrapper) -> bool {
+    // There must be the same number of errors
+    if actual.diagnostics.len() != expected.diagnostics.len() {
+        return false;
+    }
+
+    // All diagnostics must be equal
+    for (a, e) in zip(actual.diagnostics, expected.diagnostics) {
+        if !diagnostic_eq(&a, &e) {
+            println!("actual: {:#?}", a);
+            println!("expected: {:#?}", e);
+            return false;
+        }
+    }
+
+    true
+}
+
+fn run_test(asm: PathBuf, results: PathBuf) {
+    // Change the CWD to the directory of this file
+    let dir = PathBuf::from("tests/");
+    env::set_current_dir(dir).unwrap();
+
+    // Run RVA on the input assembly
+    let mut bin = rva_bin();
+    let cmd = bin
+        .arg("lint")
+        .arg("--json")
+        .arg(asm);
+
+    // Compare outputs
+    let out = String::from_utf8(cmd.output().unwrap().stdout).unwrap();
+    let actual: ListWrapper = serde_json::from_str(&out).unwrap();
+
+    let expected_str = fs::read_to_string(results).unwrap();
+    let expected: ListWrapper = serde_json::from_str(&expected_str).unwrap();
+
+    assert!(output_eq(actual, expected));
+}
+
+#[test]
+fn no_args() {
+    let mut cmd = rva_bin();
+    cmd.assert().failure();
+}
+
+#[test]
+fn sample() {
+    let asm = PathBuf::from("./sample/unused-value.s");
+    let out = PathBuf::from("./sample/unused-value.json");
+    run_test(asm, out);
+}

--- a/riscv_analysis_cli/tests/sample/unused-value.json
+++ b/riscv_analysis_cli/tests/sample/unused-value.json
@@ -1,0 +1,22 @@
+{
+  "diagnostics": [
+    {
+      "file": "sample/unused-value.s",
+      "title": "Unused value",
+      "description": "Unused value",
+      "level": "Warning",
+      "range": {
+        "start": {
+          "line": 1,
+          "column": 9,
+          "raw": 15
+        },
+        "end": {
+          "line": 1,
+          "column": 10,
+          "raw": 16
+        }
+      }
+    }
+  ]
+}

--- a/riscv_analysis_cli/tests/sample/unused-value.s
+++ b/riscv_analysis_cli/tests/sample/unused-value.s
@@ -1,0 +1,3 @@
+main:
+    addi a0, a0, 1
+    ret


### PR DESCRIPTION
**Summary**: 

This PR adds the ability to run tests that take in an assembly file, run the linter, and compare the results with a file.

**Test plan**: 

As we discover more issues, we can add representative tests with the correct outputs.