### PR TITLE
[RV-63] Modify the AV map to use the universe set representation

### DIFF
--- a/riscv_analysis/src/analysis/available.rs
+++ b/riscv_analysis/src/analysis/available.rs
@@ -221,8 +221,8 @@ fn rule_zero_to_const(
         match val.1 {
             AvailableValue::OriginalRegisterWithScalar(r, i)
             | AvailableValue::RegisterWithScalar(r, i) => {
-                if r == &Register::X0 {
-                    available_out.insert(*val.0, AvailableValue::Constant(*i));
+                if r == Register::X0 {
+                    available_out.insert(val.0, AvailableValue::Constant(i));
                 }
             }
             _ => {}
@@ -232,8 +232,8 @@ fn rule_zero_to_const(
         match val.1 {
             AvailableValue::OriginalRegisterWithScalar(r, i)
             | AvailableValue::RegisterWithScalar(r, i) => {
-                if r == &Register::X0 {
-                    memory_out.insert(val.0.clone(), AvailableValue::Constant(*i));
+                if r == Register::X0 {
+                    memory_out.insert(val.0.clone(), AvailableValue::Constant(i));
                 }
             }
             _ => {}
@@ -351,7 +351,7 @@ fn rule_known_values_to_stack(
     memory_out: &mut AvailableValueMap<MemoryLocation>,
     available_in: &AvailableValueMap<Register>,
 ) {
-    for (pos, val) in memory_out.clone() {
+    for (pos, val) in memory_out.iter() {
         if let AvailableValue::RegisterWithScalar(reg, off) = val {
             if let Some(item) = available_in.get(&reg) {
                 match item {

--- a/riscv_analysis/src/analysis/available.rs
+++ b/riscv_analysis/src/analysis/available.rs
@@ -1,9 +1,7 @@
 // AVAILABLE VALUE ANALYSIS
 // ========================
 
-use std::collections::HashSet;
 use std::hash::Hash;
-use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
 
@@ -101,6 +99,11 @@ impl GenerationPass for AvailableValuePass {
     fn run(cfg: &mut crate::cfg::Cfg) -> Result<(), Box<CfgError>> {
         let mut changed = true;
 
+        for node in cfg.iter() {
+            node.set_reg_values_out(AvailableValueMap::universe());
+            node.set_memory_values_out(AvailableValueMap::universe());
+        }
+
         // Because of this type of algorithm, there might be a back branch,
         // like a loop, that has not been visited before the first in[n] is
         // calculated. To fix this, we keep track of what nodes have been
@@ -108,16 +111,15 @@ impl GenerationPass for AvailableValuePass {
         // We still ensure that, by the end, all nodes have been visited and
         // the values with the correct previous nodes are calculated.
         #[allow(clippy::mutable_key_type)]
-        let mut visited = HashSet::new();
         while changed {
             changed = false;
             for node in cfg.iter() {
+
                 // in[n] = AND out[p] for all p in prev[n]
                 let in_reg_n = node
                     .prevs()
                     .clone()
                     .into_iter()
-                    .filter(|x| visited.contains(x))
                     .map(|x| x.reg_values_out())
                     .reduce(|mut acc, x| {
                         acc &= &x;
@@ -131,7 +133,6 @@ impl GenerationPass for AvailableValuePass {
                     .prevs()
                     .clone()
                     .into_iter()
-                    .filter(|x| visited.contains(x))
                     .map(|x| x.memory_values_out())
                     .reduce(|mut acc, x| {
                         acc &= &x;
@@ -196,9 +197,6 @@ impl GenerationPass for AvailableValuePass {
                     changed = true;
                     node.set_memory_values_out(out_memory_n);
                 }
-
-                // Add node to visited
-                visited.insert(Rc::clone(&node));
             }
         }
         Ok(())

--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -330,7 +330,7 @@ impl LintPass for LostCalleeSavedRegisterCheck {
 
                     // check stack values:
                     let stack = node.memory_values_out();
-                    for (_, val) in stack {
+                    for (_, val) in &stack {
                         if let AvailableValue::OriginalRegisterWithScalar(reg2, offset) = val {
                             if reg2 == reg.data && offset == 0 {
                                 found = true;
@@ -341,7 +341,7 @@ impl LintPass for LostCalleeSavedRegisterCheck {
 
                     // check register values:
                     let regs = node.reg_values_out();
-                    for (_, val) in regs {
+                    for (_, val) in &regs {
                         if let AvailableValue::OriginalRegisterWithScalar(reg2, offset) = val {
                             if reg2 == reg.data && offset == 0 {
                                 found = true;

--- a/riscv_analysis_cli/tests/available-value/control-flow-order.json
+++ b/riscv_analysis_cli/tests/available-value/control-flow-order.json
@@ -1,0 +1,3 @@
+{
+  "diagnostics": []
+}

--- a/riscv_analysis_cli/tests/available-value/control-flow-order.s
+++ b/riscv_analysis_cli/tests/available-value/control-flow-order.s
@@ -1,0 +1,6 @@
+main:
+    j       lower
+loop:
+    j       main
+lower:
+    j       loop

--- a/riscv_analysis_cli/tests/runner.rs
+++ b/riscv_analysis_cli/tests/runner.rs
@@ -50,7 +50,7 @@ fn output_eq(actual: TestCase, expected: TestCase) -> bool {
 fn run_test(asm: PathBuf, results: PathBuf) {
     // Change the CWD to the directory of this file
     let dir = PathBuf::from("tests/");
-    env::set_current_dir(dir).unwrap();
+    let _ = env::set_current_dir(dir);
 
     // Run RVA on the input assembly
     let mut bin = rva_bin();
@@ -79,5 +79,12 @@ fn no_args() {
 fn sample() {
     let asm = PathBuf::from("./sample/unused-value.s");
     let out = PathBuf::from("./sample/unused-value.json");
+    run_test(asm, out);
+}
+
+#[test]
+fn av_control_flow_order() {
+    let asm = PathBuf::from("./available-value/control-flow-order.s");
+    let out = PathBuf::from("./available-value/control-flow-order.json");
     run_test(asm, out);
 }


### PR DESCRIPTION
**Summary**: 
Set the AV pass to use the universe / finite test. I know that the implementation is kind of poor, but in the interest of time, I have made a few sacrifices:
- The iterator clones everything instead of using a reference.
- Some of the methods don't handle all cases (Eg. `len`)
- What should be the default? Everywhere else assumes that finite is the default.
- Printing & deserializing almost certainly don't work for the universe set.
- There are number of (probably unnecessary) clones throughout. 

**Test plan**: 
I have added a new cli test that captures the infinite looping case.
