### PR TITLE
[RV-67] Fix bug causing "Invalid use before assignment" for ret instructions

### DIFF
--- a/riscv_analysis/src/lints/checks.rs
+++ b/riscv_analysis/src/lints/checks.rs
@@ -185,7 +185,7 @@ impl LintPass for GarbageInputValueCheck {
                 }
             } else if let Some(func) = node.is_function_entry() {
                 let args = func.arguments();
-                let garbage = node.live_in() - args - RegSets::saved();
+                let garbage = node.live_in() - args - RegSets::callee_saved();
                 if !garbage.is_empty() {
                     let mut ranges = Vec::new();
                     for reg in &garbage {

--- a/riscv_analysis_cli/tests/checks/no-invalid-assign-for-ret.json
+++ b/riscv_analysis_cli/tests/checks/no-invalid-assign-for-ret.json
@@ -1,0 +1,22 @@
+{
+  "diagnostics": [
+    {
+      "file": "checks/no-invalid-assign-for-ret.s",
+      "title": "Unused value",
+      "description": "Unused value",
+      "level": "Warning",
+      "range": {
+        "start": {
+          "line": 5,
+          "column": 12,
+          "raw": 62
+        },
+        "end": {
+          "line": 5,
+          "column": 13,
+          "raw": 63
+        }
+      }
+    }
+  ]
+}

--- a/riscv_analysis_cli/tests/checks/no-invalid-assign-for-ret.s
+++ b/riscv_analysis_cli/tests/checks/no-invalid-assign-for-ret.s
@@ -1,0 +1,7 @@
+main:
+    jal     other
+    li      ra, 0
+
+other:
+    addi    a0, a0, 1   # Error for unused value
+    ret                 # There should not be an error here

--- a/riscv_analysis_cli/tests/runner.rs
+++ b/riscv_analysis_cli/tests/runner.rs
@@ -50,7 +50,7 @@ fn output_eq(actual: TestCase, expected: TestCase) -> bool {
 fn run_test(asm: PathBuf, results: PathBuf) {
     // Change the CWD to the directory of this file
     let dir = PathBuf::from("tests/");
-    env::set_current_dir(dir).unwrap();
+    let _ = env::set_current_dir(dir);
 
     // Run RVA on the input assembly
     let mut bin = rva_bin();
@@ -79,5 +79,12 @@ fn no_args() {
 fn sample() {
     let asm = PathBuf::from("./sample/unused-value.s");
     let out = PathBuf::from("./sample/unused-value.json");
+    run_test(asm, out);
+}
+
+#[test]
+fn no_invalid_assign_for_ret() {
+    let asm = PathBuf::from("./checks/no-invalid-assign-for-ret.s");
+    let out = PathBuf::from("./checks/no-invalid-assign-for-ret.json");
     run_test(asm, out);
 }


### PR DESCRIPTION
**Summary**: 

In [this](https://github.com/rajanmaghera/riscv-analysis/commit/88cf3239a01b4773958ab23ebd2da3b70d922d89#diff-e643315052a1817599e7cf60d2a086250156ac33cd2261b65b74d49e669c68f1L193) commit, `callee_saved()` was replaced with `saved()`, causing extra errors to be created for each `ret` instruction.

**Test plan**: 

An integration test for this case was added.