### PR TITLE
refactor: rename passes to -Pass

### DIFF
--- a/riscv_analysis/src/lints/callee_saved_garbage_read.rs
+++ b/riscv_analysis/src/lints/callee_saved_garbage_read.rs
@@ -3,8 +3,8 @@ use crate::parser::{HasRegisterSets, InstructionProperties, Register};
 use crate::passes::{DiagnosticManager, LintError, LintPass};
 
 // check if the value of a calle-saved register is read as its original value
-pub struct CalleeSavedGarbageReadCheck;
-impl LintPass for CalleeSavedGarbageReadCheck {
+pub struct CalleeSavedGarbageReadPass;
+impl LintPass for CalleeSavedGarbageReadPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in cfg {
             for read in node.reads_from() {

--- a/riscv_analysis/src/lints/callee_saved_register.rs
+++ b/riscv_analysis/src/lints/callee_saved_register.rs
@@ -4,8 +4,8 @@ use crate::parser::{HasRegisterSets, Register};
 use crate::passes::{DiagnosticManager, LintError, LintPass};
 
 // Check if the values of callee-saved registers are restored to the original value at the end of the function
-pub struct CalleeSavedRegisterCheck;
-impl LintPass for CalleeSavedRegisterCheck {
+pub struct CalleeSavedRegisterPass;
+impl LintPass for CalleeSavedRegisterPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for func in cfg.functions().values() {
             for exit in func.exits().iter() {

--- a/riscv_analysis/src/lints/control_flow.rs
+++ b/riscv_analysis/src/lints/control_flow.rs
@@ -11,8 +11,8 @@ use std::rc::Rc;
 /// - A function is entered through the first line of code (Why?).
 /// - A function is entered through an jump that is not a function call.
 /// - Any code that has no previous nodes, i.e. is unreachable.
-pub struct ControlFlowCheck;
-impl LintPass for ControlFlowCheck {
+pub struct ControlFlowPass;
+impl LintPass for ControlFlowPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in &cfg.clone() {
             if node.is_function_entry() {
@@ -64,7 +64,7 @@ mod tests {
         assert_eq!(parser_output.errors.len(), 0);
         let cfg = Manager::gen_full_cfg(parser_output, None, &ProgramEntryType::FirstInstruction)
             .unwrap();
-        ControlFlowCheck::run_single_pass_along_cfg(&cfg)
+        ControlFlowPass::run_single_pass_along_cfg(&cfg)
     }
 
     #[test]

--- a/riscv_analysis/src/lints/dead_value.rs
+++ b/riscv_analysis/src/lints/dead_value.rs
@@ -6,8 +6,8 @@ use crate::{
     passes::{DiagnosticManager, LintError, LintPass},
 };
 
-pub struct DeadValueCheck;
-impl LintPass for DeadValueCheck {
+pub struct DeadValuePass;
+impl LintPass for DeadValuePass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in cfg {
             // check the out of the node for any uses that

--- a/riscv_analysis/src/lints/ecall.rs
+++ b/riscv_analysis/src/lints/ecall.rs
@@ -6,8 +6,8 @@ use crate::{
 
 // Check if every ecall has a known call number
 // Check if there are any instructions after an ecall to terminate the program
-pub struct EcallCheck;
-impl LintPass for EcallCheck {
+pub struct EcallPass;
+impl LintPass for EcallPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in cfg {
             if node.is_ecall() && node.known_ecall().is_none() {

--- a/riscv_analysis/src/lints/garbage_input_value.rs
+++ b/riscv_analysis/src/lints/garbage_input_value.rs
@@ -7,8 +7,8 @@ use crate::{
 // TODO deprecate
 // Check if there are any in values to the start of functions that are not args or saved registers
 // Check if there are any in values at the start of a program
-pub struct GarbageInputValueCheck;
-impl LintPass for GarbageInputValueCheck {
+pub struct GarbageInputValuePass;
+impl LintPass for GarbageInputValuePass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in cfg {
             if node.is_program_entry() {

--- a/riscv_analysis/src/lints/instruction_in_text.rs
+++ b/riscv_analysis/src/lints/instruction_in_text.rs
@@ -10,8 +10,8 @@ use crate::{
 /// Instructions will only be assembled if they appear in
 /// the text segment. Instructions in other locations is
 /// behaviour that we do not handle.
-pub struct InstructionInTextCheck;
-impl LintPass for InstructionInTextCheck {
+pub struct InstructionInTextPass;
+impl LintPass for InstructionInTextPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in cfg {
             if node.is_instruction() && node.segment() != Segment::Text {
@@ -29,14 +29,14 @@ mod tests {
     #[test]
     fn default_segment_is_text() {
         let nodes = &[iarith!(Addi X1 X0 0)];
-        let errors = InstructionInTextCheck::run_single_pass_along_nodes(nodes);
+        let errors = InstructionInTextPass::run_single_pass_along_nodes(nodes);
         assert_eq!(errors.len(), 0);
     }
 
     #[test]
     fn explicit_text_segment_is_allowed() {
         let nodes = &[iarith!(Addi X1 X0 0 => Text)];
-        let errors = InstructionInTextCheck::run_single_pass_along_nodes(nodes);
+        let errors = InstructionInTextPass::run_single_pass_along_nodes(nodes);
         assert_eq!(errors.len(), 0);
     }
 
@@ -49,7 +49,7 @@ mod tests {
             arith!(Sub X1 X0 X20 => Data),
             iarith!(Andi X1 X0 0),
         ];
-        let errors = InstructionInTextCheck::run_single_pass_along_nodes(nodes);
+        let errors = InstructionInTextPass::run_single_pass_along_nodes(nodes);
         assert_eq!(errors.len(), 2);
         assert_eq!(errors[0].get_error_code(), "invalid-segment");
         assert_eq!(errors[1].get_error_code(), "invalid-segment");
@@ -65,7 +65,7 @@ mod tests {
             arith!(Sub X1 X0 X20),
             iarith!(Andi X1 X0 0),
         ];
-        let errors = InstructionInTextCheck::run_single_pass_along_nodes(nodes);
+        let errors = InstructionInTextPass::run_single_pass_along_nodes(nodes);
         assert_eq!(errors.len(), 3);
         assert_eq!(errors[0].get_error_code(), "invalid-segment");
         assert_eq!(errors[1].get_error_code(), "invalid-segment");

--- a/riscv_analysis/src/lints/lost_callee_saved_register.rs
+++ b/riscv_analysis/src/lints/lost_callee_saved_register.rs
@@ -6,9 +6,9 @@ use crate::passes::{DiagnosticManager, LintError, LintPass};
 // Check if the value of a calle-saved register is ever "lost" (aka. overwritten without being restored)
 // This provides a more detailed image compared to above, and could be turned into extra
 // diagnostic information in the future.
-pub struct LostCalleeSavedRegisterCheck;
+pub struct LostCalleeSavedRegisterPass;
 
-impl LintPass for LostCalleeSavedRegisterCheck {
+impl LintPass for LostCalleeSavedRegisterPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in cfg {
             let callee = Register::saved_set();

--- a/riscv_analysis/src/lints/overlapping_function.rs
+++ b/riscv_analysis/src/lints/overlapping_function.rs
@@ -10,8 +10,8 @@ use crate::{
 /// doesn't generally occur in canonical code. Instead, the existence of
 /// overlapping functions usually indicates a mistaken jump to the middle of a
 /// function.
-pub struct OverlappingFunctionCheck;
-impl LintPass for OverlappingFunctionCheck {
+pub struct OverlappingFunctionPass;
+impl LintPass for OverlappingFunctionPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in cfg {
             // Capture entry points that are part of more than one function
@@ -30,7 +30,7 @@ impl LintPass for OverlappingFunctionCheck {
 
 #[cfg(test)]
 mod tests {
-    use crate::lints::OverlappingFunctionCheck;
+    use crate::lints::OverlappingFunctionPass;
     use crate::parser::{ProgramEntryType, RVStringParser};
     use crate::passes::{DiagnosticManager, LintPass, Manager};
 
@@ -41,7 +41,7 @@ mod tests {
 
         let cfg = Manager::gen_full_cfg(parser_output, None, &ProgramEntryType::FirstInstruction)
             .unwrap(); // Need fn annotations
-        OverlappingFunctionCheck::run_single_pass_along_cfg(&cfg)
+        OverlappingFunctionPass::run_single_pass_along_cfg(&cfg)
     }
 
     #[test]

--- a/riscv_analysis/src/lints/save_to_zero.rs
+++ b/riscv_analysis/src/lints/save_to_zero.rs
@@ -2,9 +2,9 @@ use crate::cfg::Cfg;
 use crate::parser::{InstructionProperties, Register};
 use crate::passes::{DiagnosticManager, LintError, LintPass};
 
-pub struct SaveToZeroCheck;
+pub struct SaveToZeroPass;
 
-impl LintPass for SaveToZeroCheck {
+impl LintPass for SaveToZeroPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         for node in cfg {
             if let Some(register) = node.writes_to() {

--- a/riscv_analysis/src/lints/stack.rs
+++ b/riscv_analysis/src/lints/stack.rs
@@ -4,8 +4,8 @@ use crate::parser::{InstructionProperties, Register};
 use crate::passes::{DiagnosticManager, LintError, LintPass};
 
 // Check that we know the stack position at every point in the program (aka. within scopes)
-pub struct StackCheckPass;
-impl LintPass for StackCheckPass {
+pub struct StackPass;
+impl LintPass for StackPass {
     fn run(cfg: &Cfg, errors: &mut DiagnosticManager) {
         // PASS 1
         // check that we know the stack position at every point in the program

--- a/riscv_analysis/src/passes/manager.rs
+++ b/riscv_analysis/src/passes/manager.rs
@@ -9,9 +9,9 @@ use crate::{
         NodeDirectionPass,
     },
     lints::{
-        CalleeSavedGarbageReadCheck, CalleeSavedRegisterCheck, ControlFlowCheck, DeadValueCheck,
-        EcallCheck, GarbageInputValueCheck, InstructionInTextCheck, LostCalleeSavedRegisterCheck,
-        OverlappingFunctionCheck, SaveToZeroCheck, StackCheckPass,
+        CalleeSavedGarbageReadPass, CalleeSavedRegisterPass, ControlFlowPass, DeadValuePass,
+        EcallPass, GarbageInputValuePass, InstructionInTextPass, LostCalleeSavedRegisterPass,
+        OverlappingFunctionPass, SaveToZeroPass, StackPass,
     },
 };
 
@@ -61,17 +61,17 @@ impl Manager {
         Ok(cfg)
     }
     pub fn run_diagnostics(cfg: &Cfg, errors: &mut DiagnosticManager) {
-        SaveToZeroCheck::run(cfg, errors);
-        DeadValueCheck::run(cfg, errors);
-        InstructionInTextCheck::run(cfg, errors);
-        EcallCheck::run(cfg, errors);
-        ControlFlowCheck::run(cfg, errors);
-        GarbageInputValueCheck::run(cfg, errors);
-        StackCheckPass::run(cfg, errors);
-        CalleeSavedRegisterCheck::run(cfg, errors);
-        CalleeSavedGarbageReadCheck::run(cfg, errors);
-        LostCalleeSavedRegisterCheck::run(cfg, errors);
-        OverlappingFunctionCheck::run(cfg, errors);
+        SaveToZeroPass::run(cfg, errors);
+        DeadValuePass::run(cfg, errors);
+        InstructionInTextPass::run(cfg, errors);
+        EcallPass::run(cfg, errors);
+        ControlFlowPass::run(cfg, errors);
+        GarbageInputValuePass::run(cfg, errors);
+        StackPass::run(cfg, errors);
+        CalleeSavedRegisterPass::run(cfg, errors);
+        CalleeSavedGarbageReadPass::run(cfg, errors);
+        LostCalleeSavedRegisterPass::run(cfg, errors);
+        OverlappingFunctionPass::run(cfg, errors);
     }
     pub fn run(
         parser_output: RVParserOutput,


### PR DESCRIPTION
**Summary**: Use -Pass suffix on `LintPass` implementers.

To be merged in after #131 

**Test plan**: Refactor, previous tests should pass normally
