### PR TITLE
refactor: consolidate iterators on `Cfg`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ target/
 private/
 tmp/
 result
+
+.idea/

--- a/riscv_analysis/src/analysis/available.rs
+++ b/riscv_analysis/src/analysis/available.rs
@@ -121,7 +121,7 @@ impl GenerationPass for AvailableValuePass {
         let mut visited = HashSet::new();
         while changed {
             changed = false;
-            for node in cfg.iter() {
+            for node in cfg.iter_source() {
                 // in[n] = AND out[p] for all p in prev[n]
                 let mut in_reg_n = cfg
                     .get_prevs(node.as_ref())

--- a/riscv_analysis/src/analysis/available.rs
+++ b/riscv_analysis/src/analysis/available.rs
@@ -206,7 +206,7 @@ impl GenerationPass for AvailableValuePass {
                 changed |= node.set_memory_values_out(out_memory_n);
 
                 // Add node to visited
-                visited.insert(Rc::clone(&node));
+                visited.insert(Rc::clone(node));
             }
         }
         Ok(())

--- a/riscv_analysis/src/analysis/liveness.rs
+++ b/riscv_analysis/src/analysis/liveness.rs
@@ -50,7 +50,7 @@ impl GenerationPass for LivenessPass {
                     // has to come from the function.
                     let u_def = (cfg
                         .get_prevs(node.as_ref())
-                        .filter(|x| visited.contains(x.as_ref()))
+                        .filter(|x| visited.contains(x))
                         .map(|x| x.u_def())
                         .reduce(|acc, x| acc & x)
                         .unwrap_or_default()
@@ -77,7 +77,7 @@ impl GenerationPass for LivenessPass {
                     // u_def[n] = (AND u_def[s] for all s in prev[n]) - caller-saved | ecall_returns
                     let u_def = (cfg
                         .get_prevs(node.as_ref())
-                        .filter(|x| visited.contains(x.as_ref()))
+                        .filter(|x| visited.contains(x))
                         .map(|x| x.u_def())
                         .reduce(|acc, x| acc & x)
                         .unwrap_or_default()
@@ -104,7 +104,7 @@ impl GenerationPass for LivenessPass {
                     // u_def[n] = AND u_def[s] for all s in prev[n] | kill[n]
                     let u_def = (cfg
                         .get_prevs(node.as_ref())
-                        .filter(|x| visited.contains(x.as_ref()))
+                        .filter(|x| visited.contains(x))
                         .map(|x| x.u_def())
                         .reduce(|acc, x| acc & x)
                         .unwrap_or_default())

--- a/riscv_analysis/src/analysis/liveness.rs
+++ b/riscv_analysis/src/analysis/liveness.rs
@@ -16,7 +16,7 @@ impl GenerationPass for LivenessPass {
         let mut visited = HashSet::new();
         while changed {
             changed = false;
-            for node in cfg.iter().rev() {
+            for node in cfg.iter_source().rev() {
                 if node.is_return() {
                     // live_out[F_exit] = live_out[F_exit] & return-registers
                     let live_out = node.live_out() & Register::return_set();

--- a/riscv_analysis/src/cfg/display.rs
+++ b/riscv_analysis/src/cfg/display.rs
@@ -70,7 +70,7 @@ impl Display for CfgNode {
 
 impl Display for Cfg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for node in self {
+        for node in self.iter_source() {
             f.write_fmt(format_args!("{node}\n"))?;
         }
         Ok(())

--- a/riscv_analysis/src/cfg/graph.rs
+++ b/riscv_analysis/src/cfg/graph.rs
@@ -1,5 +1,4 @@
 use super::CfgBreadthFirstIterator;
-use super::CfgIterator;
 use super::CfgNode;
 use super::CfgSourceIterator;
 use super::Function;
@@ -26,15 +25,9 @@ pub struct Cfg {
 }
 
 impl Cfg {
-    /// Get an iterator over the `Cfg` nodes.
-    #[must_use]
-    pub fn iter(&self) -> CfgIterator {
-        CfgIterator::new(self)
-    }
-
     /// Get an iterator over the `Cfg` nodes in source order.
     #[must_use]
-    pub fn iter_source(&self) -> CfgSourceIterator {
+    pub fn iter_source(&self) -> CfgSourceIterator<'_> {
         CfgSourceIterator::new(self)
     }
 
@@ -60,15 +53,6 @@ impl Cfg {
     #[must_use]
     pub fn nodes(&self) -> &Vec<Rc<CfgNode>> {
         &self.nodes
-    }
-}
-
-impl<'a> IntoIterator for &'a Cfg {
-    type IntoIter = CfgIterator<'a>;
-    type Item = &'a Rc<CfgNode>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
     }
 }
 

--- a/riscv_analysis/src/cfg/graph.rs
+++ b/riscv_analysis/src/cfg/graph.rs
@@ -42,14 +42,14 @@ impl Cfg {
     /// Get an iterator over the `Cfg` nodes that are reachable using the
     /// nexts of `node`.
     #[must_use]
-    pub fn iter_nexts(&self, node: Rc<CfgNode>) -> CfgNextsIterator {
+    pub fn iter_nexts<'a>(&'a self, node: &'a Rc<CfgNode>) -> CfgNextsIterator<'a> {
         CfgNextsIterator::new(self, node)
     }
 
     /// Get an iterator over the `Cfg` nodes that are reachable using the
     /// prevs of `node`.
     #[must_use]
-    pub fn iter_prevs(&self, node: Rc<CfgNode>) -> CfgPrevsIterator {
+    pub fn iter_prevs<'a>(&'a self, node: &'a Rc<CfgNode>) -> CfgPrevsIterator<'a> {
         CfgPrevsIterator::new(self, node)
     }
 
@@ -73,7 +73,7 @@ impl Cfg {
 
 impl<'a> IntoIterator for &'a Cfg {
     type IntoIter = CfgIterator<'a>;
-    type Item = Rc<CfgNode>;
+    type Item = &'a Rc<CfgNode>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/riscv_analysis/src/cfg/graph.rs
+++ b/riscv_analysis/src/cfg/graph.rs
@@ -1,7 +1,6 @@
+use super::CfgBreadthFirstIterator;
 use super::CfgIterator;
-use super::CfgNextsIterator;
 use super::CfgNode;
-use super::CfgPrevsIterator;
 use super::CfgSourceIterator;
 use super::Function;
 use crate::analysis::HasGenKillInfo;
@@ -42,15 +41,8 @@ impl Cfg {
     /// Get an iterator over the `Cfg` nodes that are reachable using the
     /// nexts of `node`.
     #[must_use]
-    pub fn iter_nexts<'a>(&'a self, node: &'a Rc<CfgNode>) -> CfgNextsIterator<'a> {
-        CfgNextsIterator::new(self, node)
-    }
-
-    /// Get an iterator over the `Cfg` nodes that are reachable using the
-    /// prevs of `node`.
-    #[must_use]
-    pub fn iter_prevs<'a>(&'a self, node: &'a Rc<CfgNode>) -> CfgPrevsIterator<'a> {
-        CfgPrevsIterator::new(self, node)
+    pub fn iter_breadth_first<'a>(&'a self, node: &'a Rc<CfgNode>) -> CfgBreadthFirstIterator<'a> {
+        CfgBreadthFirstIterator::new(self, node)
     }
 
     /// Get the functions of the CFG.

--- a/riscv_analysis/src/cfg/interrupt_handler.rs
+++ b/riscv_analysis/src/cfg/interrupt_handler.rs
@@ -86,7 +86,7 @@ impl Cfg {
         let mut interrupt_handler_names = HashSet::new();
 
         // Look for names of labels that are set to the interrupt vector CSR.
-        for node in self {
+        for node in self.iter_source() {
             if let Some((csr, Some(AvailableValue::Address(label)))) = node.sets_csr_to_value() {
                 if csr.is_interrupt_vector() {
                     interrupt_handler_names.insert(label);

--- a/riscv_analysis/src/cfg/iterator.rs
+++ b/riscv_analysis/src/cfg/iterator.rs
@@ -43,7 +43,7 @@ impl DoubleEndedIterator for CfgSourceIterator<'_> {
 pub struct CfgBreadthFirstIterator<'a> {
     cfg: &'a Cfg,
     queue: Vec<&'a Rc<CfgNode>>, // Nodes we have seen but not visited yet
-    visted: HashSet<&'a Rc<CfgNode>>, // Nodes we have visited
+    visited: HashSet<&'a Rc<CfgNode>>, // Nodes we have visited
 }
 
 impl<'a> CfgBreadthFirstIterator<'a> {
@@ -53,7 +53,7 @@ impl<'a> CfgBreadthFirstIterator<'a> {
         Self {
             cfg,
             queue: vec![start],
-            visted: HashSet::new(),
+            visited: HashSet::new(),
         }
     }
 }
@@ -65,12 +65,12 @@ impl<'a> Iterator for CfgBreadthFirstIterator<'a> {
         // If the queue runs out, there are no more nodes that are reachable
         while let Some(node) = self.queue.pop() {
             // Skip over nodes we have already visited
-            if self.visted.contains(node) {
+            if self.visited.contains(node) {
                 continue;
             }
 
             // Mark this node as visited
-            self.visted.insert(node);
+            self.visited.insert(node);
 
             // Add all successor nodes to the queue
             for suc in self.cfg.get_nexts(node) {

--- a/riscv_analysis/src/cfg/iterator.rs
+++ b/riscv_analysis/src/cfg/iterator.rs
@@ -1,113 +1,21 @@
-use crate::{
-    cfg::{Cfg, CfgNode},
-    passes::DiagnosticLocation,
-};
+use crate::cfg::{Cfg, CfgNode};
 use std::{collections::HashSet, rc::Rc};
-
-/// Iterate over all nodes in a CFG.
-pub struct CfgIterator<'a> {
-    nodes: &'a Vec<Rc<CfgNode>>,
-    start: usize, // Location in the iteration
-    end: usize,
-    end_final: bool, // True if `end` has reached the start
-}
-
-impl<'a> CfgIterator<'a> {
-    /// Create a new iterator over all nodes in the CFG.
-    ///
-    /// Useful if you don't care about the order of the nodes.
-    #[must_use]
-    pub fn new(cfg: &'a Cfg) -> Self {
-        let nodes = &cfg.nodes();
-        let mut end_final = false;
-        let end = match nodes.len() {
-            0 => {
-                end_final = true;
-                0
-            }
-            l => l - 1,
-        };
-
-        Self {
-            nodes,
-            start: 0,
-            end,
-            end_final,
-        }
-    }
-
-    fn in_bounds(&self) -> bool {
-        self.start <= self.end && !self.end_final
-    }
-}
-
-impl<'a> Iterator for CfgIterator<'a> {
-    type Item = &'a Rc<CfgNode>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if !self.in_bounds() {
-            return None;
-        }
-
-        // Return the next node, if there is one
-        if let Some(node) = self.nodes.get(self.start) {
-            self.start += 1;
-            return Some(node);
-        }
-
-        None
-    }
-}
-
-impl DoubleEndedIterator for CfgIterator<'_> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if !self.in_bounds() {
-            return None;
-        }
-
-        let result = self.nodes.get(self.end);
-
-        if self.end == 0 {
-            self.end_final = true;
-        } else {
-            self.end -= 1;
-        }
-
-        result
-    }
-}
 
 /// Iterate over all nodes in the order that they appear in the source file.
 ///
-/// If there are multiple files, nodes in the same file will be grouped, but
-/// the files will not be given in any particular order.
+/// If there are multiple files, nodes in the same file will be grouped by
+/// the order they are included.
 pub struct CfgSourceIterator<'a> {
-    nodes: Vec<&'a Rc<CfgNode>>,
-    start: usize,
+    nodes: std::slice::Iter<'a, Rc<CfgNode>>,
 }
 
 impl<'a> CfgSourceIterator<'a> {
     /// Create a new source order iterator
     #[must_use]
     pub fn new(cfg: &'a Cfg) -> Self {
-        let mut nodes = cfg.nodes().iter().collect::<Vec<_>>();
-
-        // Sort by location
-        nodes.sort_by(|a, b| {
-            let a_token = a.range();
-            let b_token = b.range();
-            a_token.end().cmp(b_token.end())
-        });
-
-        // Sort by file. We know that `sort_by` is stable, so this has the
-        // effect of grouping by file
-        nodes.sort_by(|a, b| {
-            let a_file = a.file();
-            let b_file = b.file();
-            a_file.cmp(&b_file)
-        });
-
-        Self { nodes, start: 0 }
+        Self {
+            nodes: cfg.nodes().iter(),
+        }
     }
 }
 
@@ -115,13 +23,13 @@ impl<'a> Iterator for CfgSourceIterator<'a> {
     type Item = &'a Rc<CfgNode>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Return the next node, if there is one
-        if let Some(node) = self.nodes.get(self.start) {
-            self.start += 1;
-            return Some(node);
-        }
+        self.nodes.next()
+    }
+}
 
-        None
+impl DoubleEndedIterator for CfgSourceIterator<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.nodes.next_back()
     }
 }
 
@@ -192,7 +100,7 @@ mod tests {
     fn empty() {
         let input = "";
         let cfg = gen_cfg(input);
-        let mut iterator = cfg.iter();
+        let mut iterator = cfg.iter_source();
 
         iterator.next(); // There is a program entry node by default
         assert_eq!(iterator.next(), None);

--- a/riscv_analysis/src/cfg/iterator.rs
+++ b/riscv_analysis/src/cfg/iterator.rs
@@ -41,8 +41,8 @@ impl<'a> CfgIterator<'a> {
     }
 }
 
-impl Iterator for CfgIterator<'_> {
-    type Item = Rc<CfgNode>;
+impl<'a> Iterator for CfgIterator<'a> {
+    type Item = &'a Rc<CfgNode>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if !self.in_bounds() {
@@ -52,7 +52,7 @@ impl Iterator for CfgIterator<'_> {
         // Return the next node, if there is one
         if let Some(node) = self.nodes.get(self.start) {
             self.start += 1;
-            return Some(Rc::clone(node));
+            return Some(node);
         }
 
         None
@@ -65,7 +65,7 @@ impl DoubleEndedIterator for CfgIterator<'_> {
             return None;
         }
 
-        let result = self.nodes.get(self.end).map(Rc::clone);
+        let result = self.nodes.get(self.end);
 
         if self.end == 0 {
             self.end_final = true;
@@ -81,16 +81,16 @@ impl DoubleEndedIterator for CfgIterator<'_> {
 ///
 /// If there are multiple files, nodes in the same file will be grouped, but
 /// the files will not be given in any particular order.
-pub struct CfgSourceIterator {
-    nodes: Vec<Rc<CfgNode>>,
+pub struct CfgSourceIterator<'a> {
+    nodes: Vec<&'a Rc<CfgNode>>,
     start: usize,
 }
 
-impl CfgSourceIterator {
+impl<'a> CfgSourceIterator<'a> {
     /// Create a new source order iterator
     #[must_use]
-    pub fn new(cfg: &Cfg) -> Self {
-        let mut nodes = cfg.nodes().clone();
+    pub fn new(cfg: &'a Cfg) -> Self {
+        let mut nodes = cfg.nodes().iter().collect::<Vec<_>>();
 
         // Sort by location
         nodes.sort_by(|a, b| {
@@ -111,14 +111,14 @@ impl CfgSourceIterator {
     }
 }
 
-impl Iterator for CfgSourceIterator {
-    type Item = Rc<CfgNode>;
+impl<'a> Iterator for CfgSourceIterator<'a> {
+    type Item = &'a Rc<CfgNode>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Return the next node, if there is one
         if let Some(node) = self.nodes.get(self.start) {
             self.start += 1;
-            return Some(Rc::clone(node));
+            return Some(node);
         }
 
         None
@@ -134,14 +134,14 @@ impl Iterator for CfgSourceIterator {
 /// You must not modify the key of any CFG node during the traversal.
 pub struct CfgNextsIterator<'a> {
     cfg: &'a Cfg,
-    queue: Vec<Rc<CfgNode>>,      // Nodes we have seen but not visited yet
-    visted: HashSet<Rc<CfgNode>>, // Nodes we have visited
+    queue: Vec<&'a Rc<CfgNode>>, // Nodes we have seen but not visited yet
+    visted: HashSet<&'a Rc<CfgNode>>, // Nodes we have visited
 }
 
 impl<'a> CfgNextsIterator<'a> {
     /// Create a new iterator over all nodes reachable from `start`.
     #[must_use]
-    pub fn new(cfg: &'a Cfg, start: Rc<CfgNode>) -> Self {
+    pub fn new(cfg: &'a Cfg, start: &'a Rc<CfgNode>) -> Self {
         Self {
             cfg,
             queue: vec![start],
@@ -150,23 +150,23 @@ impl<'a> CfgNextsIterator<'a> {
     }
 }
 
-impl Iterator for CfgNextsIterator<'_> {
-    type Item = Rc<CfgNode>;
+impl<'a> Iterator for CfgNextsIterator<'a> {
+    type Item = &'a Rc<CfgNode>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // If the queue runs out, there are no more nodes that are reachable
         while let Some(node) = self.queue.pop() {
             // Skip over nodes we have already visited
-            if self.visted.contains(&node) {
+            if self.visted.contains(node) {
                 continue;
             }
 
             // Mark this node as visited
-            self.visted.insert(Rc::clone(&node));
+            self.visted.insert(node);
 
             // Add all successor nodes to the queue
-            for suc in self.cfg.get_nexts(node.as_ref()) {
-                self.queue.push(Rc::clone(suc));
+            for suc in self.cfg.get_nexts(node) {
+                self.queue.push(suc);
             }
 
             return Some(node);
@@ -185,14 +185,14 @@ impl Iterator for CfgNextsIterator<'_> {
 /// You must not modify the key of any CFG node during the traversal.
 pub struct CfgPrevsIterator<'a> {
     cfg: &'a Cfg,
-    queue: Vec<Rc<CfgNode>>,      // Nodes we have seen but not visited yet
-    visted: HashSet<Rc<CfgNode>>, // Nodes we have visited
+    queue: Vec<&'a Rc<CfgNode>>, // Nodes we have seen but not visited yet
+    visted: HashSet<&'a Rc<CfgNode>>, // Nodes we have visited
 }
 
 impl<'a> CfgPrevsIterator<'a> {
     /// Create a new iterator over all nodes reachable from `start`.
     #[must_use]
-    pub fn new(cfg: &'a Cfg, start: Rc<CfgNode>) -> Self {
+    pub fn new(cfg: &'a Cfg, start: &'a Rc<CfgNode>) -> Self {
         Self {
             cfg,
             queue: vec![start],
@@ -201,8 +201,8 @@ impl<'a> CfgPrevsIterator<'a> {
     }
 }
 
-impl Iterator for CfgPrevsIterator<'_> {
-    type Item = Rc<CfgNode>;
+impl<'a> Iterator for CfgPrevsIterator<'a> {
+    type Item = &'a Rc<CfgNode>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // If the queue runs out, there are no more nodes that are reachable
@@ -213,11 +213,11 @@ impl Iterator for CfgPrevsIterator<'_> {
             }
 
             // Mark this node as visited
-            self.visted.insert(Rc::clone(&node));
+            self.visted.insert(node);
 
             // Add all successor nodes to the queue
-            for suc in self.cfg.get_prevs(node.as_ref()) {
-                self.queue.push(Rc::clone(suc));
+            for suc in self.cfg.get_prevs(node) {
+                self.queue.push(suc);
             }
 
             return Some(node);

--- a/riscv_analysis/src/cfg/iterator.rs
+++ b/riscv_analysis/src/cfg/iterator.rs
@@ -132,13 +132,13 @@ impl<'a> Iterator for CfgSourceIterator<'a> {
 /// over.
 ///
 /// You must not modify the key of any CFG node during the traversal.
-pub struct CfgNextsIterator<'a> {
+pub struct CfgBreadthFirstIterator<'a> {
     cfg: &'a Cfg,
     queue: Vec<&'a Rc<CfgNode>>, // Nodes we have seen but not visited yet
     visted: HashSet<&'a Rc<CfgNode>>, // Nodes we have visited
 }
 
-impl<'a> CfgNextsIterator<'a> {
+impl<'a> CfgBreadthFirstIterator<'a> {
     /// Create a new iterator over all nodes reachable from `start`.
     #[must_use]
     pub fn new(cfg: &'a Cfg, start: &'a Rc<CfgNode>) -> Self {
@@ -150,7 +150,7 @@ impl<'a> CfgNextsIterator<'a> {
     }
 }
 
-impl<'a> Iterator for CfgNextsIterator<'a> {
+impl<'a> Iterator for CfgBreadthFirstIterator<'a> {
     type Item = &'a Rc<CfgNode>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -166,57 +166,6 @@ impl<'a> Iterator for CfgNextsIterator<'a> {
 
             // Add all successor nodes to the queue
             for suc in self.cfg.get_nexts(node) {
-                self.queue.push(suc);
-            }
-
-            return Some(node);
-        }
-
-        None
-    }
-}
-
-/// Iterate over all CFG nodes reachable from some start node, using the prevs.
-///
-/// This iterator uses the `prevs()` functions of each CFG node. Thus if the
-/// `NodeDirectionPass` has not run yet, only the start node will be iterated
-/// over.
-///
-/// You must not modify the key of any CFG node during the traversal.
-pub struct CfgPrevsIterator<'a> {
-    cfg: &'a Cfg,
-    queue: Vec<&'a Rc<CfgNode>>, // Nodes we have seen but not visited yet
-    visted: HashSet<&'a Rc<CfgNode>>, // Nodes we have visited
-}
-
-impl<'a> CfgPrevsIterator<'a> {
-    /// Create a new iterator over all nodes reachable from `start`.
-    #[must_use]
-    pub fn new(cfg: &'a Cfg, start: &'a Rc<CfgNode>) -> Self {
-        Self {
-            cfg,
-            queue: vec![start],
-            visted: HashSet::new(),
-        }
-    }
-}
-
-impl<'a> Iterator for CfgPrevsIterator<'a> {
-    type Item = &'a Rc<CfgNode>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // If the queue runs out, there are no more nodes that are reachable
-        while let Some(node) = self.queue.pop() {
-            // Skip over nodes we have already visited
-            if self.visted.contains(&node) {
-                continue;
-            }
-
-            // Mark this node as visited
-            self.visted.insert(node);
-
-            // Add all successor nodes to the queue
-            for suc in self.cfg.get_prevs(node) {
                 self.queue.push(suc);
             }
 

--- a/riscv_analysis/src/cfg/node.rs
+++ b/riscv_analysis/src/cfg/node.rs
@@ -1,3 +1,10 @@
+use super::environment_in_outs;
+use super::AvailableValueMap;
+use super::Cfg;
+use super::Function;
+use super::RefCellReplacement;
+use super::RegisterSet;
+use super::Segment;
 use crate::analysis::AvailableValue;
 use crate::analysis::MemoryLocation;
 use crate::parser::InstructionProperties;
@@ -9,14 +16,6 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::rc::Rc;
-
-use super::environment_in_outs;
-use super::AvailableValueMap;
-use super::Cfg;
-use super::Function;
-use super::RefCellReplacement;
-use super::RegisterSet;
-use super::Segment;
 
 #[derive(Debug)]
 pub struct CfgNode {

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -108,7 +108,7 @@ pub struct CfgWrapper(Vec<NodeWrapper>);
 
 impl From<&Cfg> for CfgWrapper {
     fn from(cfg: &Cfg) -> Self {
-        CfgWrapper(cfg.iter().map(|x| NodeWrapper::from(&x, cfg)).collect())
+        CfgWrapper(cfg.iter().map(|x| NodeWrapper::from(x, cfg)).collect())
     }
 }
 

--- a/riscv_analysis/src/cfg/test_wrapper.rs
+++ b/riscv_analysis/src/cfg/test_wrapper.rs
@@ -65,7 +65,7 @@ impl NodeWrapper {
                 .functions()
                 .iter()
                 .map(|func| {
-                    cfg.iter()
+                    cfg.iter_source()
                         .position(|other| func.entry().id() == other.id())
                         .unwrap()
                 })
@@ -77,7 +77,7 @@ impl NodeWrapper {
                     func.exits()
                         .iter()
                         .map(|exit| {
-                            cfg.iter()
+                            cfg.iter_source()
                                 .position(|other| exit.id() == other.id())
                                 .unwrap()
                         })
@@ -86,11 +86,11 @@ impl NodeWrapper {
                 .collect::<Vec<_>>(),
             nexts: cfg
                 .get_nexts(node)
-                .map(|x| cfg.iter().position(|y| x.id() == y.id()).unwrap())
+                .map(|x| cfg.iter_source().position(|y| x.id() == y.id()).unwrap())
                 .collect(),
             prevs: cfg
                 .get_prevs(node)
-                .map(|x| cfg.iter().position(|y| x.id() == y.id()).unwrap())
+                .map(|x| cfg.iter_source().position(|y| x.id() == y.id()).unwrap())
                 .collect(),
             reg_values_in: node.reg_values_in(),
             reg_values_out: node.reg_values_out(),
@@ -108,7 +108,11 @@ pub struct CfgWrapper(Vec<NodeWrapper>);
 
 impl From<&Cfg> for CfgWrapper {
     fn from(cfg: &Cfg) -> Self {
-        CfgWrapper(cfg.iter().map(|x| NodeWrapper::from(x, cfg)).collect())
+        CfgWrapper(
+            cfg.iter_source()
+                .map(|x| NodeWrapper::from(x, cfg))
+                .collect(),
+        )
     }
 }
 

--- a/riscv_analysis/src/gen/dead_code.rs
+++ b/riscv_analysis/src/gen/dead_code.rs
@@ -63,6 +63,6 @@ mod test {
         let mut cfg = Cfg::new(parser_output, None, &ProgramEntryType::FirstInstruction).unwrap();
         NodeDirectionPass::run(&mut cfg)?;
         EliminateDeadCodeDirectionsPass::run(&mut cfg)?;
-        Ok(cfg.iter().collect())
+        Ok(cfg.iter().cloned().collect())
     }
 }

--- a/riscv_analysis/src/gen/dead_code.rs
+++ b/riscv_analysis/src/gen/dead_code.rs
@@ -63,6 +63,6 @@ mod test {
         let mut cfg = Cfg::new(parser_output, None, &ProgramEntryType::FirstInstruction).unwrap();
         NodeDirectionPass::run(&mut cfg)?;
         EliminateDeadCodeDirectionsPass::run(&mut cfg)?;
-        Ok(cfg.iter().cloned().collect())
+        Ok(cfg.iter_source().cloned().collect())
     }
 }

--- a/riscv_analysis/src/gen/directions.rs
+++ b/riscv_analysis/src/gen/directions.rs
@@ -23,19 +23,19 @@ impl GenerationPass for NodeDirectionPass {
                     .iter()
                     .find(|n| n.labels().contains(&label))
                     .ok_or_else(|| CfgError::UnexpectedError)?;
-                edges_to_insert.push((Rc::clone(&node), Rc::clone(&jump_to_node)));
+                edges_to_insert.push((Rc::clone(node), Rc::clone(jump_to_node)));
             }
 
             // Linearly scan for nexts and prevs
             if let Some(p) = prev {
-                edges_to_insert.push((Rc::clone(&p), Rc::clone(&node)));
+                edges_to_insert.push((Rc::clone(&p), Rc::clone(node)));
             }
 
             // Set previous node to current node, if it is not a return
             prev = if node.is_return() || node.is_unconditional_jump() {
                 None
             } else {
-                Some(Rc::clone(&node))
+                Some(Rc::clone(node))
             }
         }
         for (from, to) in edges_to_insert {

--- a/riscv_analysis/src/gen/directions.rs
+++ b/riscv_analysis/src/gen/directions.rs
@@ -16,11 +16,11 @@ impl GenerationPass for NodeDirectionPass {
     fn run(cfg: &mut Cfg) -> Result<(), Box<CfgError>> {
         let mut prev: Option<Rc<CfgNode>> = None;
         let mut edges_to_insert = Vec::new();
-        for node in cfg.iter() {
+        for node in cfg.iter_source() {
             // If node jumps to another node, add it to the nexts of the current node and the prevs of the node it jumps to.
             if let Some(label) = node.jumps_to() {
                 let jump_to_node = cfg
-                    .iter()
+                    .iter_source()
                     .find(|n| n.labels().contains(&label))
                     .ok_or_else(|| CfgError::UnexpectedError)?;
                 edges_to_insert.push((Rc::clone(node), Rc::clone(jump_to_node)));

--- a/riscv_analysis/src/gen/ecall_terminate.rs
+++ b/riscv_analysis/src/gen/ecall_terminate.rs
@@ -6,7 +6,7 @@ pub struct EcallTerminationPass;
 impl GenerationPass for EcallTerminationPass {
     fn run(cfg: &mut crate::cfg::Cfg) -> Result<(), Box<CfgError>> {
         let mut edges_to_remove = Vec::new();
-        for node in cfg.iter() {
+        for node in cfg.iter_source() {
             if node.is_program_exit() {
                 for temp_node in cfg.get_nexts(node.as_ref()) {
                     edges_to_remove.push((Rc::clone(node), Rc::clone(temp_node)));

--- a/riscv_analysis/src/gen/ecall_terminate.rs
+++ b/riscv_analysis/src/gen/ecall_terminate.rs
@@ -9,7 +9,7 @@ impl GenerationPass for EcallTerminationPass {
         for node in cfg.iter() {
             if node.is_program_exit() {
                 for temp_node in cfg.get_nexts(node.as_ref()) {
-                    edges_to_remove.push((Rc::clone(&node), Rc::clone(temp_node)));
+                    edges_to_remove.push((Rc::clone(node), Rc::clone(temp_node)));
                 }
             }
         }

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -46,7 +46,8 @@ impl FunctionMarkupPass {
 
 impl GenerationPass for FunctionMarkupPass {
     fn run(cfg: &mut Cfg) -> Result<(), Box<CfgError>> {
-        for entry in &cfg.clone() {
+        let mut functions_to_insert = Vec::new();
+        for entry in cfg.clone().iter_source() {
             // Skip all nodes that are not entry points
             if !entry.is_function_entry() {
                 continue;
@@ -59,17 +60,21 @@ impl GenerationPass for FunctionMarkupPass {
             let func = Rc::new(Function::new(labels.clone(), vec![], Rc::clone(entry)));
 
             for label in &labels {
-                cfg.insert_function(label.clone(), Rc::clone(&func));
+                functions_to_insert.push((label.clone(), Rc::clone(&func)));
             }
 
             // Mark all CFG nodes that are reachable from this entry point
-            let data = Self::mark_reachable(cfg, entry, &Rc::clone(&func));
+            let data = Self::mark_reachable(cfg, entry, &func);
             #[allow(unused_must_use)]
             func.set_defs(data.found);
             #[allow(unused_must_use)]
             func.set_nodes(data.instructions);
             #[allow(unused_must_use)]
             func.set_exits(data.returns);
+        }
+
+        for (label, func) in functions_to_insert {
+            cfg.insert_function(label, func);
         }
 
         Ok(())
@@ -128,7 +133,7 @@ mod tests {
         assert_eq!(funcs.len(), 0);
 
         // All nodes should have no function annotations
-        for node in &cfg {
+        for node in cfg.iter_source() {
             assert_eq!(node.functions().len(), 0);
         }
     }

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -20,7 +20,7 @@ impl FunctionMarkupPass {
         let mut instructions = Vec::new();
 
         // Traverse the CFG for all nodes reachable from the entry point
-        for node in cfg.iter_nexts(entry) {
+        for node in cfg.iter_breadth_first(entry) {
             // Mark the node as being a part of the given function
             instructions.push(Rc::clone(node));
             node.insert_function(Rc::clone(func));

--- a/riscv_analysis/src/gen/function_annotations.rs
+++ b/riscv_analysis/src/gen/function_annotations.rs
@@ -20,9 +20,9 @@ impl FunctionMarkupPass {
         let mut instructions = Vec::new();
 
         // Traverse the CFG for all nodes reachable from the entry point
-        for node in cfg.iter_nexts(Rc::clone(entry)) {
+        for node in cfg.iter_nexts(entry) {
             // Mark the node as being a part of the given function
-            instructions.push(Rc::clone(&node));
+            instructions.push(Rc::clone(node));
             node.insert_function(Rc::clone(func));
 
             // Collect any registers written to by the node
@@ -32,7 +32,7 @@ impl FunctionMarkupPass {
 
             // Collect return instructions
             if node.is_return() {
-                returns.push(Rc::clone(&node));
+                returns.push(Rc::clone(node));
             }
         }
 
@@ -56,14 +56,14 @@ impl GenerationPass for FunctionMarkupPass {
             let labels = entry.labels().iter().cloned().collect::<Vec<_>>();
 
             // Insert a new function into the CFG
-            let func = Rc::new(Function::new(labels.clone(), vec![], Rc::clone(&entry)));
+            let func = Rc::new(Function::new(labels.clone(), vec![], Rc::clone(entry)));
 
             for label in &labels {
                 cfg.insert_function(label.clone(), Rc::clone(&func));
             }
 
             // Mark all CFG nodes that are reachable from this entry point
-            let data = Self::mark_reachable(cfg, &entry, &Rc::clone(&func));
+            let data = Self::mark_reachable(cfg, entry, &Rc::clone(&func));
             #[allow(unused_must_use)]
             func.set_defs(data.found);
             #[allow(unused_must_use)]

--- a/riscv_analysis/src/lints/callee_saved_garbage_read.rs
+++ b/riscv_analysis/src/lints/callee_saved_garbage_read.rs
@@ -24,7 +24,7 @@ impl LintPass for CalleeSavedGarbageReadPass {
     }
 
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in cfg {
+        for node in cfg.iter_source() {
             for read in node.reads_from() {
                 // if the node uses a calle saved register but not a memory access and the value going in is the original value, then we are reading a garbage value
                 // DESIGN DECISION: we allow any memory accesses for calle saved registers

--- a/riscv_analysis/src/lints/control_flow.rs
+++ b/riscv_analysis/src/lints/control_flow.rs
@@ -30,7 +30,7 @@ impl LintPass for ControlFlowPass {
         "control-flow"
     }
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in &cfg.clone() {
+        for node in cfg.iter_source() {
             if node.is_function_entry() {
                 for function in node.functions().iter() {
                     // If the previous nodes set is not empty

--- a/riscv_analysis/src/lints/dead_value.rs
+++ b/riscv_analysis/src/lints/dead_value.rs
@@ -26,7 +26,7 @@ impl LintPass for DeadValuePass {
         "dead-value"
     }
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in cfg {
+        for node in cfg.iter_source() {
             // check the out of the node for any uses that
             // should not be there (temporaries)
             // TODO merge with Callee saved register check

--- a/riscv_analysis/src/lints/dead_value.rs
+++ b/riscv_analysis/src/lints/dead_value.rs
@@ -40,7 +40,7 @@ impl LintPass for DeadValuePass {
                 // that item is found
                 let mut ranges = Vec::new();
                 for item in &out {
-                    ranges.append(&mut cfg.error_ranges_for_first_usage(&node, item));
+                    ranges.append(&mut cfg.error_ranges_for_first_usage(node, item));
                 }
                 for item in ranges {
                     errors.push(LintError::InvalidUseAfterCall(

--- a/riscv_analysis/src/lints/ecall.rs
+++ b/riscv_analysis/src/lints/ecall.rs
@@ -26,7 +26,7 @@ impl LintPass for EcallPass {
         "ecall"
     }
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in cfg {
+        for node in cfg.iter_source() {
             if node.is_ecall() && node.known_ecall().is_none() {
                 errors.push(LintError::UnknownEcall(node.node().clone()));
             }

--- a/riscv_analysis/src/lints/garbage_input_value.rs
+++ b/riscv_analysis/src/lints/garbage_input_value.rs
@@ -34,7 +34,7 @@ impl LintPass for GarbageInputValuePass {
                 if !garbage.is_empty() {
                     let mut ranges = Vec::new();
                     for reg in &garbage {
-                        let mut ranges_tmp = cfg.error_ranges_for_first_usage(&node, reg);
+                        let mut ranges_tmp = cfg.error_ranges_for_first_usage(node, reg);
                         ranges.append(&mut ranges_tmp);
                     }
                     for range in ranges {
@@ -47,7 +47,7 @@ impl LintPass for GarbageInputValuePass {
                 if !garbage.is_empty() {
                     let mut ranges = Vec::new();
                     for reg in &garbage {
-                        let mut ranges_tmp = cfg.error_ranges_for_first_usage(&node, reg);
+                        let mut ranges_tmp = cfg.error_ranges_for_first_usage(node, reg);
                         ranges.append(&mut ranges_tmp);
                     }
                     for range in ranges {

--- a/riscv_analysis/src/lints/garbage_input_value.rs
+++ b/riscv_analysis/src/lints/garbage_input_value.rs
@@ -27,7 +27,7 @@ impl LintPass for GarbageInputValuePass {
         "garbage-input-value"
     }
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in cfg {
+        for node in cfg.iter_source() {
             if node.is_program_entry() {
                 // get registers
                 let garbage = node.live_in() - Register::program_args_set();

--- a/riscv_analysis/src/lints/instruction_in_text.rs
+++ b/riscv_analysis/src/lints/instruction_in_text.rs
@@ -30,7 +30,7 @@ impl LintPass for InstructionInTextPass {
         "instruction-in-text"
     }
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in cfg {
+        for node in cfg.iter_source() {
             if node.is_instruction() && node.segment() != Segment::Text {
                 errors.push(LintError::InvalidSegment(node.node().clone()));
             }

--- a/riscv_analysis/src/lints/lost_callee_saved_register.rs
+++ b/riscv_analysis/src/lints/lost_callee_saved_register.rs
@@ -26,7 +26,7 @@ impl LintPass for LostCalleeSavedRegisterPass {
         "lost-called-saved-register"
     }
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in cfg {
+        for node in cfg.iter_source() {
             let callee = Register::saved_set();
 
             // If: within a function, node stores to a saved register,

--- a/riscv_analysis/src/lints/overlapping_function.rs
+++ b/riscv_analysis/src/lints/overlapping_function.rs
@@ -30,7 +30,7 @@ impl LintPass for OverlappingFunctionPass {
         "overlapping-function"
     }
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in cfg {
+        for node in cfg.iter_source() {
             // Capture entry points that are part of more than one function
             // NOTE: We only give an error for the first line of a function,
             //       even though there may be many overlapping instructions.

--- a/riscv_analysis/src/lints/save_to_zero.rs
+++ b/riscv_analysis/src/lints/save_to_zero.rs
@@ -22,7 +22,7 @@ impl LintPass for SaveToZeroPass {
         "save-to-zero"
     }
     fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-        for node in cfg {
+        for node in cfg.iter_source() {
             if let Some(register) = node.writes_to() {
                 if register == Register::X0 && !node.can_skip_save_checks() {
                     errors.push(LintError::SaveToZero(register.clone()));

--- a/riscv_analysis/src/lints/stack.rs
+++ b/riscv_analysis/src/lints/stack.rs
@@ -29,7 +29,7 @@ impl LintPass for StackPass {
         // check that the stack is never in an invalid position
         // TODO check that the stack stores always happen to a place that is negative
         // TODO move to impl methods
-        'outer: for node in cfg {
+        'outer: for node in cfg.iter_source() {
             let values = node.reg_values_out();
             match values.get(&Register::X2) {
                 None => {

--- a/riscv_analysis/src/passes/pass.rs
+++ b/riscv_analysis/src/passes/pass.rs
@@ -32,7 +32,7 @@ pub trait LintPass {
     ///       "my-pass"
     ///    }
     ///    fn run(&self, cfg: &Cfg, errors: &mut DiagnosticManager) {
-    ///       for node in cfg {
+    ///       for node in cfg.iter_source() {
     ///         errors.push(LintError::InvalidStackPointer(node.node()));
     ///      }
     ///   }


### PR DESCRIPTION
**Summary**: This PR cleans up some confusing naming on the CFG iterators. It:
- returns borrowed `&Rc<CfgNode>` rather than cloning the entire pointer, which will make it easier to eliminate Rc's in the future
- consolidates the iterators into `.iter_source()`, `.iter_breadth_first()`, `.get_nexts()`, `get_prevs()`.
- removes `IntoIterator` on `&Cfg`, so anyone iterating over the nodes must be explicit in how they want to iterate
- fixes a typo

To be merged in after #132 

**Test plan**: No new functionality, so original tests should pass as is.